### PR TITLE
patch for issue #20 : use ZipObject for this.files

### DIFF
--- a/jszip.js
+++ b/jszip.js
@@ -164,7 +164,7 @@ JSZip.prototype = (function ()
 
       o = prepareFileAttrs(o);
 
-      return this.files[name] = {name: name, data: data, options:o};
+      return this.files[name] = new ZipObject(name, data, o);
    };
 
 

--- a/test/index.html
+++ b/test/index.html
@@ -666,7 +666,8 @@ Adapted from http://stackoverflow.com/questions/1095102/how-do-i-load-binary-ima
    testZipFile("Zip text file with UTF-8 characters in filename", "ref/utf8_in_name.zip", function(file) {
       var zip = new JSZip(file);
       ok(zip.file("€15.txt") !== null, "the utf8 file is here.");
-      equal(zip.file("€15.txt").asText(), "€15\n", "the utf8 content was correctly read.");
+      equal(zip.file("€15.txt").asText(), "€15\n", "the utf8 content was correctly read (with file().asText).");
+      equal(zip.files["€15.txt"].asText(), "€15\n", "the utf8 content was correctly read (with files[].astext).");
    });
    // }}} Load file
 


### PR DESCRIPTION
This patch allows the following syntax : `unzip.files[jsonFile].asText()`, see issue #20
