### PR TITLE
Handling folder entries for Java programs

### DIFF
--- a/jszip.js
+++ b/jszip.js
@@ -78,6 +78,9 @@ JSZip.prototype = (function () {
        */
       asText : function () {
          var result = this.data;
+         if (result == null) {	
+            return result;	
+         }
          if (this.options.base64) {
             result = JSZipBase64.decode(result);
          }


### PR DESCRIPTION
Hello !

We found that Java programs cannot read zip generated by JSZip.
It appears that using the DEFLATE compression on folder entries with empty content cause the Java zip inflator to fail (error 'invalid stored block lengths').

This fix totally remove content when compressing a folder entry, and set compression to none for this entry. All tests passed, without modification on them.

Thank you !

Damien.
