### PR TITLE
Fix file.as<output_format>() with bad data.

### DIFF
--- a/jszip.js
+++ b/jszip.js
@@ -78,8 +78,8 @@ JSZip.prototype = (function () {
        */
       asText : function () {
          var result = this.data;
-         if (result === null) {
-            return result;
+         if (result === null || typeof result === "undefined") {
+            return "";
          }
          if (this.options.base64) {
             result = JSZipBase64.decode(result);
@@ -95,8 +95,8 @@ JSZip.prototype = (function () {
        */
       asBinary : function () {
          var result = this.data;
-         if (result === null) {
-            return result;
+         if (result === null || typeof result === "undefined") {
+            return "";
          }
          if (this.options.base64) {
             result = JSZipBase64.decode(result);
@@ -191,7 +191,9 @@ JSZip.prototype = (function () {
 
       o = prepareFileAttrs(o);
 
-      if (o.dir) {
+      if (o.dir || data === null || typeof data === "undefined") {
+         o.base64 = false;
+         o.binary = false;
          data = null;
       } else if (JSZip.support.uint8array && data instanceof Uint8Array) {
          o.base64 = false;

--- a/test/index.html
+++ b/test/index.html
@@ -526,6 +526,61 @@ Adapted from http://stackoverflow.com/questions/1095102/how-do-i-load-binary-ima
       }
    }
 
+   function testEmptyFileDataGetters (zip) {
+      equals(zip.file("amount.txt").asText(), "", "asText()");
+      equals(zip.file("amount.txt").asBinary(), "", "asBinary()");
+      if (JSZip.support.arraybuffer) {
+         var buffer = zip.file("amount.txt").asArrayBuffer();
+         ok(buffer instanceof ArrayBuffer, "The result is a instance of ArrayBuffer");
+         var actual = String.fromCharCode.apply(null, new Uint8Array(buffer));
+         equals(actual, "", "asArrayBuffer()");
+      } else {
+         try {
+            zip.file("amount.txt").asArrayBuffer();
+            ok(false, "no exception thrown");
+         } catch (e) {
+            ok(e.message.match("not supported by this browser"), "the error message is useful");
+         }
+      }
+      if (JSZip.support.uint8array) {
+         var bufferView = zip.file("amount.txt").asUint8Array();
+         ok(bufferView instanceof Uint8Array, "The result is a instance of Uint8Array");
+         var actual = String.fromCharCode.apply(null, bufferView);
+         equals(actual, "", "asUint8Array()");
+      } else {
+         try {
+            zip.file("amount.txt").asUint8Array();
+            ok(false, "no exception thrown");
+         } catch (e) {
+            ok(e.message.match("not supported by this browser"), "the error message is useful");
+         }
+      }
+   }
+
+   test("add file: file(name, undefined)", function() {
+      var zip = new JSZip(), undef;
+      zip.file("amount.txt", undef);
+      testEmptyFileDataGetters(zip);
+      zip = new JSZip();
+      zip.file("amount.txt", undef, {binary:true});
+      testEmptyFileDataGetters(zip);
+      zip = new JSZip();
+      zip.file("amount.txt", undef, {base64:true});
+      testEmptyFileDataGetters(zip);
+   });
+
+   test("add file: file(name, null)", function() {
+      var zip = new JSZip();
+      zip.file("amount.txt", null);
+      testEmptyFileDataGetters(zip);
+      zip = new JSZip();
+      zip.file("amount.txt", null, {binary:true});
+      testEmptyFileDataGetters(zip);
+      zip = new JSZip();
+      zip.file("amount.txt", null, {base64:true});
+      testEmptyFileDataGetters(zip);
+   });
+
    test("add file: file(name, string)", function() {
       var zip = new JSZip();
       zip.file("amount.txt", "€15\n");


### PR DESCRIPTION
If a file is added with unexpected data (null or undefined), the
results of .asText/asBinary/asUint8Array/asArrayBuffer aren't
consistent (and the generate method will fail).

With a null / undefined value, asText() will return this value but will
fail if the file is flagged as binary (or base64). The other getters
will also fail : if asBinary does not return a string, asUint8Array and
asArrayBuffer will fail.

With this patch, every getters will return "" (instead of null /
undefined / exception) for bad data. As a side effect,
zip.file("test.txt", undefined) won't break anything (we will treat it
like "").
