### PR TITLE
separate attribution comment & use "/*!" for it

### DIFF
--- a/jszip.js
+++ b/jszip.js
@@ -1,11 +1,12 @@
-/**
+/*!
 
 JSZip - A Javascript class for generating and reading zip files
 <http://stuartk.com/jszip>
 
 (c) 2009-2012 Stuart Knightley <stuart [at] stuartk.com>
 Dual licenced under the MIT license or GPLv3. See LICENSE.markdown.
-
+*/
+/**
 Usage:
    zip = new JSZip();
    zip.file("hello.txt", "Hello, World!").file("tempfile", "nothing");


### PR DESCRIPTION
Use "/*!" to ensure attribution comment is preserved by minifiers.
