### PR TITLE
move exclutions to package.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,6 @@ module.exports = function(grunt) {
         },
         options: {
           standalone: 'JSZip',
-          ignore:['./lib/nodeBuffer.js','./lib/nodeBufferReader'],
           postBundleCB: function(err, src, done) {
             // add the license
             var license = require('fs').readFileSync('lib/license_header.js');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "test-browser": "grunt build && grunt test",
     "lint": "grunt jshint"
   },
+  "browser": {
+    "./nodeBuffer": false,
+    "./nodeBufferReader": false
+  },
   "contributors": [
     {
       "name": "Franz Buchinger"


### PR DESCRIPTION
this means anyone building it downstream will also ignore those files
