### PR TITLE
zlib.js version 0.1.7 is now available in npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-uglify": "~0.2.4"
   },
   "dependencies":{
-       "zlib.js" : "git://github.com/imaya/zlib.js#0.1.7"
+    "zlibjs": "~0.1.7"
   },
   "license": "MIT or GPLv3"
 }


### PR DESCRIPTION
Fix #90.
