### PR TITLE
upgrade zlibjs to version 0.2.0, fix #104

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-uglify": "~0.2.4"
   },
   "dependencies":{
-    "zlibjs": "~0.1.7"
+    "zlibjs": "~0.2.0"
   },
   "license": "MIT or GPLv3"
 }


### PR DESCRIPTION
We are starting to use a newer `zlibjs` package.

Resolves #104.
