### PR TITLE
fix the url of the downloadify demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@ location.href="data:application/zip;base64,"+content;
 	  <p>The biggest issue with JSZip is that the filenames are very awkward, Firefox generates filenames such as <code>a5sZQRsx.zip.part</code> (see bugs <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=367231">367231</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=532230">532230</a>), and Safari isn't much better with just <code>Unknown</code>. Sadly there is no pure Javascript solution (and working in every browsers) to this. However...</p>
 
       <h4>Solution-ish: <a href="https://github.com/dcneiner/downloadify">Downloadify</a></h4>
-      <p>Downloadify uses a small Flash SWF to download files to a user's computer with a filename that you can choose. Doug Neiner has added the <code>dataType</code> option to allow you to pass a zip for downloading. Follow the <a href="http://downloadify.info/downloadify/test.html">Downloadify demo</a> with the following changes:</p>
+      <p>Downloadify uses a small Flash SWF to download files to a user's computer with a filename that you can choose. Doug Neiner has added the <code>dataType</code> option to allow you to pass a zip for downloading. Follow the <a href="http://pixelgraphics.us/downloadify/test.html">Downloadify demo</a> with the following changes:</p>
       <pre class="example">
 zip = new JSZip();
 zip.file("Hello.", "hello.txt");


### PR DESCRIPTION
See #110, the link of the downloadify demo is broken.
