### PR TITLE
Replace zlib.js with pako.

### DIFF
--- a/lib/flate.js
+++ b/lib/flate.js
@@ -1,17 +1,14 @@
 'use strict';
 var USE_TYPEDARRAY = (typeof Uint8Array !== 'undefined') && (typeof Uint16Array !== 'undefined') && (typeof Uint32Array !== 'undefined');
 
-var  ZlibDeflate = require('zlibjs/bin/rawdeflate.min').Zlib;
-var  ZlibInflate = require('zlibjs/bin/rawinflate.min').Zlib;
+var pako = require("pako");
 exports.uncompressInputType = USE_TYPEDARRAY ? "uint8array" : "array";
 exports.compressInputType = USE_TYPEDARRAY ? "uint8array" : "array";
 
 exports.magic = "\x08\x00";
 exports.compress = function(input) {
-    var deflate = new ZlibDeflate.RawDeflate(input);
-    return deflate.compress();
+    return pako.deflateRaw(input);
 };
 exports.uncompress =  function(input) {
-    var inflate = new ZlibInflate.RawInflate(input);
-    return inflate.decompress();
+    return pako.inflateRaw(input);
 };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-uglify": "~0.2.4"
   },
   "dependencies":{
-    "zlibjs": "~0.2.0"
+    "pako": "~0.1.1"
   },
   "license": "MIT or GPLv3"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -846,9 +846,6 @@ testZipFile("STORE doesn't compress", "ref/store.zip", function(expected) {
    ok(similar(actual, expected, 18) , "Generated ZIP matches reference ZIP");
 });
 
-/*
-// commented because the new implementation of DEFLATE produces different results from the old one.
-
 // zip -6 -X deflate.zip Hello.txt
 testZipFile("DEFLATE compress", "ref/deflate.zip", function(expected) {
    var zip = new JSZip();
@@ -859,7 +856,7 @@ testZipFile("DEFLATE compress", "ref/deflate.zip", function(expected) {
 
    ok(similar(actual, expected, 18) , "Generated ZIP matches reference ZIP");
 });
-*/
+
 test("Lazy decompression works", function () {
    var zip = new JSZip();
    zip.folder("test/").file("Hello.txt", "hello !");


### PR DESCRIPTION
This pull request replaces zlib.js with pako, see #102 for more details.

It also fixes #112 (decompression error on Windows).
