### PR TITLE
use SVG to display Travis CI build testing status

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ images/
 Test status
 -----------
 
-[![Build Status](https://secure.travis-ci.org/Stuk/jszip.png?branch=master)](http://travis-ci.org/Stuk/jszip)
+[![Build Status](https://api.travis-ci.org/Stuk/jszip.svg?branch=master)](http://travis-ci.org/Stuk/jszip)
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/jszip.svg)](https://saucelabs.com/u/jszip)
 


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
