### PR TITLE
Fix small typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,7 +614,7 @@ zip.filter(function (relativePath, file){
       <h2><a href="https://github.com/Stuk/jszip/blob/master/CHANGES.md">Changelog</a></h2>
 
       <h2 id="migrating_guide">Migrating Guide</h2>
-      <h3>Fromt 2.0.0 to 2.1.0</h3>
+      <h3>From 2.0.0 to 2.1.0</h3>
       <p>
          <ul>
             <li>The packaging changed : instead of loading jszip.js, jszip-load.js, jszip-inflate.js, jszip-deflate.js, just include dist/jszip.js or dist/jszip.min.js</li>


### PR DESCRIPTION
remove extra 't' in one of the migration guide headings
