### PR TITLE
Upgrade pako

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jszip-utils": "~0.0.1"
   },
   "dependencies":{
-    "pako": "~0.1.1"
+    "pako": "~0.2.1"
   },
   "license": "MIT or GPLv3"
 }


### PR DESCRIPTION
Pako v0.2.1 fixes a bug(see nodeca/pako#22), fixing #126.
The unit tests (node + saucelabs) pass and the failing test of #126 is now ok.
