### PR TITLE
Allow node.js Buffers in browser, since browserify provides them automatically. Fixes #139

### DIFF
--- a/lib/support.js
+++ b/lib/support.js
@@ -3,8 +3,10 @@ exports.base64 = true;
 exports.array = true;
 exports.string = true;
 exports.arraybuffer = typeof ArrayBuffer !== "undefined" && typeof Uint8Array !== "undefined";
-// contains true if JSZip can read/generate nodejs Buffer, false otherwise, aka checks if we arn't in a browser.
-exports.nodebuffer = !process.browser;
+// contains true if JSZip can read/generate nodejs Buffer, false otherwise.
+// Browserify will provide a Buffer implementation for browsers, which is
+// an augmented Uint8Array (i.e., can be used as either Buffer or U8).
+exports.nodebuffer = typeof Buffer !== "undefined";
 // contains true if JSZip can read/generate Uint8Array, false otherwise.
 exports.uint8array = typeof Uint8Array !== "undefined";
 

--- a/package.json
+++ b/package.json
@@ -9,10 +9,6 @@
     "test-browser": "grunt build && grunt test",
     "lint": "grunt jshint"
   },
-  "browser": {
-    "./nodeBuffer": false,
-    "./nodeBufferReader": false
-  },
   "contributors": [
     {
       "name": "Franz Buchinger"


### PR DESCRIPTION
This allowed me to do what I needed, namely, use Buffers (i.e., augmented Uint8Arrays created by browserify) when creating and extracting files from zip archives.
