### PR TITLE
Remove usage of Text{En,De}coder.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -12,11 +12,6 @@ var utf8 = require('./utf8');
 var StringWriter = require('./stringWriter');
 var Uint8ArrayWriter = require('./uint8ArrayWriter');
 
-var textEncoder;
-if (support.uint8array && typeof TextEncoder === "function") {
-    textEncoder = new TextEncoder("utf-8");
-}
-
 /**
  * Returns the raw data of a ZipObject, decompress the content if necessary.
  * @param {ZipObject} file the file to use.
@@ -54,9 +49,6 @@ var getBinaryData = function(file) {
         if (!file.options.binary) {
             // unicode text !
             // unicode string => binary string is a painful process, check if we can avoid it.
-            if (textEncoder) {
-                return textEncoder.encode(result);
-            }
             if (support.nodebuffer) {
                 return nodeBuffer(result, "utf-8");
             }

--- a/lib/utf8.js
+++ b/lib/utf8.js
@@ -4,16 +4,6 @@ var utils = require('./utils');
 var support = require('./support');
 var nodeBuffer = require('./nodeBuffer');
 
-var textEncoder, textDecoder;
-if (
-    support.uint8array &&
-    typeof TextEncoder === "function" &&
-    typeof TextDecoder === "function"
-) {
-    textEncoder = new TextEncoder("utf-8");
-    textDecoder = new TextDecoder("utf-8");
-}
-
 /**
  * The following functions come from pako, from pako/lib/utils/strings
  * released under the MIT license, see pako https://github.com/nodeca/pako/
@@ -176,12 +166,6 @@ var buf2string = function (buf) {
  * @return {Array|Uint8Array|Buffer} the UTF-8 encoded string.
  */
 exports.utf8encode = function utf8encode(str) {
-    // TextEncoder + Uint8Array to binary string is faster than checking every bytes on long strings.
-    // http://jsperf.com/utf8encode-vs-textencoder
-    // On short strings (file names for example), the TextEncoder API is (currently) slower.
-    if (textEncoder) {
-        return textEncoder.encode(str);
-    }
     if (support.nodebuffer) {
         return nodeBuffer(str, "utf-8");
     }
@@ -197,13 +181,6 @@ exports.utf8encode = function utf8encode(str) {
  * @return {String} the decoded string.
  */
 exports.utf8decode = function utf8decode(buf) {
-    // check if we can use the TextDecoder API
-    // see http://encoding.spec.whatwg.org/#api
-    if (textDecoder) {
-        return textDecoder.decode(
-            utils.transformTo("uint8array", buf)
-        );
-    }
     if (support.nodebuffer) {
         return utils.transformTo("nodebuffer", buf).toString("utf-8");
     }


### PR DESCRIPTION
The goal was to provide a faster utf8 encoding / decoding. This API is only
available on Firefox and it doesn't work well in a Firefox addon context
(the generated Uint8Array and the available Uint8Array class come from
different contexts, leading to bugs and performance issues).

Instead of adding more conditions to (try to) detect if the Uint8Array
is from the same context or not, I think it's better to remove this
optimization for now.

Fix #151.
