### PR TITLE
change `createSubFolders` to just `createFolders`

### DIFF
--- a/documentation/api_jszip/file_data.md
+++ b/documentation/api_jszip/file_data.md
@@ -24,7 +24,7 @@ date        | date    | the current date | the last modification date.
 compression | string  | null    | If set, specifies compression method to use for this specific file. If not, the default file compression will be used, see [generate(options)]({{site.baseurl}}/documentation/api_jszip/generate.html).
 comment     | string  | null    | The comment for this file.
 optimizedBinaryString | boolean | `false` | Set to true if (and only if) the input is a "binary string" and has already been prepared with a 0xFF mask.
-createSubFolders | boolean | `false` | Set to true if folders in the file path should be automatically created, otherwise there will only be virtual folders that represent the path to the file.
+createFolders | boolean | `false` | Set to true if folders in the file path should be automatically created, otherwise there will only be virtual folders that represent the path to the file.
 
 You shouldn't update the data given to this method : it is kept as it so any
 update will impact the stored data.
@@ -62,7 +62,7 @@ zip.file("animals.txt", "dog,platypus\n").file("people.txt", "james,sebastian\n"
 // In the above case, the "folder" folder will not have a 'D'irectory attribute or Method property. The
 // folder only exists as part of the path to "file.txt".
 
-zip.file("folder/file.txt", "file in folder", {createSubFolders: true});
+zip.file("folder/file.txt", "file in folder", {createFolders: true});
 // In this case, the "folder" folder WILL have a 'D'irectory attribute and a Method property of "store".
 // It will exist whether or not "file.txt" is present.
 ```

--- a/documentation/api_jszip/load.md
+++ b/documentation/api_jszip/load.md
@@ -22,7 +22,7 @@ name                          | type    | default | description
 options.base64                | boolean | false   | set to `true` if the data is base64 encoded, `false` for binary.
 options.checkCRC32            | boolean | false   | set to `true` if the read data should be checked against its CRC32.
 options.optimizedBinaryString | boolean | false   | set to true if (and only if) the input is a string and has already been prepared with a 0xFF mask.
-options.createSubFolders      | boolean | false   | set to true to create folders in the file path automatically. Leaving it false will result in only virtual folders (i.e. folders that merely represent part of the file path) being created.
+options.createFolders      | boolean | false   | set to true to create folders in the file path automatically. Leaving it false will result in only virtual folders (i.e. folders that merely represent part of the file path) being created.
 
 You shouldn't update the data given to this method : it is kept as it so any
 update will impact the stored data.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,7 +2,7 @@
 exports.base64 = false;
 exports.binary = false;
 exports.dir = false;
-exports.createSubFolders = false;
+exports.createFolders = false;
 exports.date = null;
 exports.compression = null;
 exports.comment = null;

--- a/lib/load.js
+++ b/lib/load.js
@@ -18,7 +18,7 @@ module.exports = function(data, options) {
             date: input.date,
             dir: input.dir,
             comment : input.fileComment.length ? input.fileComment : null,
-            createSubFolders: options.createSubFolders
+            createFolders: options.createFolders
         });
     }
     if (zipEntries.zipComment.length) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -231,7 +231,7 @@ var fileAdd = function(name, data, o) {
 
     o = prepareFileAttrs(o);
 
-    if (o.createSubFolders && (parent = parentFolder(name))) {
+    if (o.createFolders && (parent = parentFolder(name))) {
         folderAdd.call(this, parent, true);
     }
 
@@ -287,23 +287,23 @@ var parentFolder = function (path) {
  * Add a (sub) folder in the current folder.
  * @private
  * @param {string} name the folder's name
- * @param {boolean=} [createSubFolders] If true, automatically create sub 
+ * @param {boolean=} [createFolders] If true, automatically create sub 
  *  folders. Defaults to false.
  * @return {Object} the new folder.
  */
-var folderAdd = function(name, createSubFolders) {
+var folderAdd = function(name, createFolders) {
     // Check the name ends with a /
     if (name.slice(-1) != "/") {
         name += "/"; // IE doesn't like substr(-1)
     }
 
-    createSubFolders = (typeof createSubFolders !== 'undefined') ? createSubFolders : false;
+    createFolders = (typeof createFolders !== 'undefined') ? createFolders : false;
 
     // Does this folder already exist?
     if (!this.files[name]) {
         fileAdd.call(this, name, null, {
             dir: true,
-            createSubFolders: createSubFolders
+            createFolders: createFolders
         });
     }
     return this.files[name];

--- a/test/test.js
+++ b/test/test.js
@@ -1233,9 +1233,9 @@ if (QUnit.urlParams.complexfiles) {
       ok(zip.file("[Content_Types].xml").asText().indexOf("application/vnd.ms-package.xps-fixeddocument+xml") !== -1, "the zip was correctly read.");
    });
 
-    // Same test as above, but with createSubFolders option set to true
+    // Same test as above, but with createFolders option set to true
     testZipFile("Outlook2007_Calendar.xps", "ref/complex_files/Outlook2007_Calendar.xps", function(file) {
-        var zip = new JSZip(file, {createSubFolders: true});
+        var zip = new JSZip(file, {createFolders: true});
         // the zip file contains 15 entries, but we get 23 when creating all the sub-folders.
         equal(zip.filter(function(){return true;}).length, 23, "the zip contains the good number of elements.");
         ok(zip.file("[Content_Types].xml").asText().indexOf("application/vnd.ms-package.xps-fixeddocument+xml") !== -1, "the zip was correctly read.");
@@ -1250,9 +1250,9 @@ if (QUnit.urlParams.complexfiles) {
       ok(zip.file("[Content_Types].xml").asText().indexOf("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml") !== -1, "the zip was correctly read.");
    });
 
-   // Same test as above, but with createSubFolders option set to true
+   // Same test as above, but with createFolders option set to true
    testZipFile("AntarcticaTemps.xlsx", "ref/complex_files/AntarcticaTemps.xlsx", function(file) {
-       var zip = new JSZip(file, {createSubFolders: true});
+       var zip = new JSZip(file, {createFolders: true});
        // the zip file contains 16 entries, but we get 27 when creating all the sub-folders.
        equal(zip.filter(function(){return true;}).length, 27, "the zip contains the good number of elements.");
        ok(zip.file("[Content_Types].xml").asText().indexOf("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml") !== -1, "the zip was correctly read.");
@@ -1268,7 +1268,7 @@ if (QUnit.urlParams.complexfiles) {
 
    // same as above, but in the Open Document format
    testZipFile("AntarcticaTemps.ods", "ref/complex_files/AntarcticaTemps.ods", function (file) {
-       var zip = new JSZip(file, {createSubFolders: true});
+       var zip = new JSZip(file, {createFolders: true});
        // the zip file contains 19 entries, but we get 27 when creating all the sub-folders.
        equal(zip.filter(function () {return true;}).length, 27, "the zip contains the good number of elements.");
        ok(zip.file("META-INF/manifest.xml").asText().indexOf("application/vnd.oasis.opendocument.spreadsheet") !== -1, "the zip was correctly read.");


### PR DESCRIPTION
updated references in defaults, load, object, and test script files, as well as in file_data and load documentation files.
