### PR TITLE
Add an option to set the DEFLATE level.

### DIFF
--- a/documentation/api_jszip/file_data.md
+++ b/documentation/api_jszip/file_data.md
@@ -22,6 +22,7 @@ base64      | boolean | `false` | set to `true` if the data is base64 encoded. F
 binary      | boolean | `false` | set to `true` if the data should be treated as raw content, `false` if this is a text. If base64 is used, this defaults to `true`, if the data is not a string, this will be set to `true`.
 date        | date    | the current date | the last modification date.
 compression | string  | null    | If set, specifies compression method to use for this specific file. If not, the default file compression will be used, see [generate(options)]({{site.baseurl}}/documentation/api_jszip/generate.html).
+compressionOptions | object | `null` | the options to use when compressing the file, see [generate(options)]({{site.baseurl}}/documentation/api_jszip/generate.html).
 comment     | string  | null    | The comment for this file.
 optimizedBinaryString | boolean | `false` | Set to true if (and only if) the input is a "binary string" and has already been prepared with a 0xFF mask.
 createFolders | boolean | `false` | Set to true if folders in the file path should be automatically created, otherwise there will only be virtual folders that represent the path to the file.

--- a/documentation/api_jszip/generate.md
+++ b/documentation/api_jszip/generate.md
@@ -37,7 +37,7 @@ between 1 (best speed) and 9 (best compression)).
 
 Note : if the entry is *already* compressed (coming from a compressed zip file),
 calling `generate()` with a different compression level won't update the entry.
-The reason is simple : JSZip doesn't know how was compressed the content and
+The reason is simple : JSZip doesn't know how compressed the content was and
 how to match the compression level with the implementation we use.
 
 Note for the `comment` option : the zip format has no flag or field to give the

--- a/documentation/api_jszip/generate.md
+++ b/documentation/api_jszip/generate.md
@@ -13,6 +13,7 @@ name                | type    | default | description
 options             | object  |         | the options to generate the zip file :
 options.base64      | boolean | false   | **deprecated**, use `type` instead. If `type` is not used, set to `false` to get the result as a raw byte string, `true` to encode it as base64.
 options.compression | string  | `STORE` (no compression) | the default file compression method to use. Available methods are `STORE` and `DEFLATE`. You can also provide your own compression method.
+options.compressionOptions | object | `null` | the options to use when compressing the file, see below.
 options.type        | string  | `base64` | The type of zip to return, see below for the other types.
 options.comment     | string  |          | The comment to use for the zip file.
 options.mimeType    | string  | `application/zip` | mime-type for the generated file. Useful when you need to generate a file with a different extension, ie: ".ods".
@@ -28,6 +29,16 @@ Possible values for `type` :
 
 Note : when using type = "uint8array", "arraybuffer" or "blob", be sure to
 check if the browser supports it (you can use [`JSZip.support`]({{site.baseurl}}/documentation/api_jszip/support.html)).
+
+The `compressionOptions` parameter depends on the compression type. With
+`STORE` (no compression), this parameter is ignored. With `DEFLATE`, you can
+give the compression level with `compressionOptions : {level:6}` (or any level
+between 1 (best speed) and 9 (best compression)).
+
+Note : if the entry is *already* compressed (coming from a compressed zip file),
+calling `generate()` with a different compression level won't update the entry.
+The reason is simple : JSZip doesn't know how was compressed the content and
+how to match the compression level with the implementation we use.
 
 Note for the `comment` option : the zip format has no flag or field to give the
 encoding of this field and JSZip will use UTF-8. With non ASCII characters you

--- a/lib/compressions.js
+++ b/lib/compressions.js
@@ -1,7 +1,7 @@
 'use strict';
 exports.STORE = {
     magic: "\x00\x00",
-    compress: function(content) {
+    compress: function(content, compressionOptions) {
         return content; // no compression
     },
     uncompress: function(content) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,4 +5,5 @@ exports.dir = false;
 exports.createFolders = false;
 exports.date = null;
 exports.compression = null;
+exports.compressionOptions = null;
 exports.comment = null;

--- a/lib/flate.js
+++ b/lib/flate.js
@@ -6,8 +6,10 @@ exports.uncompressInputType = USE_TYPEDARRAY ? "uint8array" : "array";
 exports.compressInputType = USE_TYPEDARRAY ? "uint8array" : "array";
 
 exports.magic = "\x08\x00";
-exports.compress = function(input) {
-    return pako.deflateRaw(input);
+exports.compress = function(input, compressionOptions) {
+    return pako.deflateRaw(input, {
+        level : compressionOptions.level || -1 // default compression
+    });
 };
 exports.uncompress =  function(input) {
     return pako.inflateRaw(input);

--- a/lib/object.js
+++ b/lib/object.js
@@ -305,9 +305,10 @@ var folderAdd = function(name, createFolders) {
  * Generate a JSZip.CompressedObject for a given zipOject.
  * @param {ZipObject} file the object to read.
  * @param {JSZip.compression} compression the compression to use.
+ * @param {Object} compressionOptions the options to use when compressing.
  * @return {JSZip.CompressedObject} the compressed result.
  */
-var generateCompressedObjectFrom = function(file, compression) {
+var generateCompressedObjectFrom = function(file, compression, compressionOptions) {
     var result = new CompressedObject(),
         content;
 
@@ -327,7 +328,7 @@ var generateCompressedObjectFrom = function(file, compression) {
         else {
             content = file._data.getContent();
             // need to decompress / recompress
-            result.compressedContent = compression.compress(utils.transformTo(compression.compressInputType, content));
+            result.compressedContent = compression.compress(utils.transformTo(compression.compressInputType, content), compressionOptions);
         }
     }
     else {
@@ -339,7 +340,7 @@ var generateCompressedObjectFrom = function(file, compression) {
         }
         result.uncompressedSize = content.length;
         result.crc32 = crc32(content);
-        result.compressedContent = compression.compress(utils.transformTo(compression.compressInputType, content));
+        result.compressedContent = compression.compress(utils.transformTo(compression.compressInputType, content), compressionOptions);
     }
 
     result.compressedSize = result.compressedContent.length;
@@ -646,6 +647,7 @@ var out = {
         options = extend(options || {}, {
             base64: true,
             compression: "STORE",
+            compressionOptions : null,
             type: "base64",
             comment: null,
             mimeType: 'application/zip'
@@ -671,8 +673,9 @@ var out = {
             if (!compression) {
                 throw new Error(compressionName + " is not a valid compression method !");
             }
+            var compressionOptions = file.options.compressionOptions || options.compressionOptions || {};
 
-            var compressedObject = generateCompressedObjectFrom.call(this, file, compression);
+            var compressedObject = generateCompressedObjectFrom.call(this, file, compression, compressionOptions);
 
             var zipPart = generateZipParts.call(this, name, file, compressedObject, localDirLength);
             localDirLength += zipPart.fileRecord.length + compressedObject.compressedSize;

--- a/test/test.js
+++ b/test/test.js
@@ -988,6 +988,34 @@ test("Empty files / folders are not compressed", function() {
    JSZip.compressions.DEFLATE.compress = oldDeflateCompress;
 });
 
+test("DEFLATE level on generate()", function() {
+   var zip = new JSZip();
+   zip.file("Hello.txt", "world");
+
+   var oldDeflateCompress = JSZip.compressions.DEFLATE.compress;
+   JSZip.compressions.DEFLATE.compress = function (str, options) {
+      equal(options.level, 5);
+      return str;
+   };
+   zip.generate({compression:'DEFLATE', compressionOptions : {level:5}});
+
+   JSZip.compressions.DEFLATE.compress = oldDeflateCompress;
+});
+
+test("DEFLATE level on file() takes precedence", function() {
+   var zip = new JSZip();
+   zip.file("Hello.txt", "world", {compressionOptions:{level:9}});
+
+   var oldDeflateCompress = JSZip.compressions.DEFLATE.compress;
+   JSZip.compressions.DEFLATE.compress = function (str, options) {
+      equal(options.level, 9);
+      return str;
+   };
+   zip.generate({compression:'DEFLATE', compressionOptions : {level:5}});
+
+   JSZip.compressions.DEFLATE.compress = oldDeflateCompress;
+});
+
 test("unknown compression throws an exception", function () {
    var zip = new JSZip().file("file.txt", "test");
    try {


### PR DESCRIPTION
This commit adds a new option, `compressionOptions`. If it contains a field
`level`, it is used by the DEFLATE compression to set the compression level :
6 by default or any level between 1 (best speed) and 9 (best compression).

Fix #165.