### PR TITLE
Improve the error message with corrupted zip.

### DIFF
--- a/lib/zipEntries.js
+++ b/lib/zipEntries.js
@@ -132,7 +132,24 @@ ZipEntries.prototype = {
     readEndOfCentral: function() {
         var offset = this.reader.lastIndexOfSignature(sig.CENTRAL_DIRECTORY_END);
         if (offset === -1) {
-            throw new Error("Corrupted zip : can't find end of central directory");
+            // Check if the content is a truncated zip or complete garbage.
+            // A "LOCAL_FILE_HEADER" is not required at the beginning (auto
+            // extractible zip for example) but it can give a good hint.
+            // If an ajax request was used without responseType, we will also
+            // get unreadable data.
+            var isGarbage = true;
+            try {
+                this.reader.setIndex(0);
+                this.checkSignature(sig.LOCAL_FILE_HEADER);
+                isGarbage = false;
+            } catch (e) {}
+
+            if (isGarbage) {
+                throw new Error("Can't find end of central directory : is this a zip file ? " +
+                                "If it is, see http://stuk.github.io/jszip/documentation/howto/read_zip.html");
+            } else {
+                throw new Error("Corrupted zip : can't find end of central directory");
+            }
         }
         this.reader.setIndex(offset);
         this.checkSignature(sig.CENTRAL_DIRECTORY_END);

--- a/test/test.js
+++ b/test/test.js
@@ -1049,6 +1049,24 @@ testZipFile("bad offset", "ref/invalid/bad_offset.zip", function(file) {
       ok(e.message.match("Corrupted zip"), "the error message is useful");
    }
 });
+
+test("truncated zip file", function() {
+   try {
+      var zip = new JSZip("PK\x03\x04\x0A\x00\x00\x00<cut>");
+      ok(false, "no exception were thrown");
+   } catch(e) {
+      ok(e.message.match("Corrupted zip"), "the error message is useful");
+   }
+});
+
+test("not a zip file", function() {
+   try {
+      var zip = new JSZip("I'm not a zip file");
+      ok(false, "no exception were thrown");
+   } catch(e) {
+      ok(e.message.match("stuk.github.io/jszip/documentation"), "the error message is useful");
+   }
+});
 // }}} Load file, corrupted zip
 
 QUnit.module("Load file"); // {{{


### PR DESCRIPTION
Check if the content is a truncated zip or complete garbage.

A "LOCAL_FILE_HEADER" is not required at the beginning (auto extractible zip
for example) but it can give a good hint. If an ajax request was used without
responseType, we will also get unreadable data.

Fix #182.