### PR TITLE
Use an SPDX expression for license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
   "dependencies":{
     "pako": "~0.2.5"
   },
-  "license": "MIT or GPLv3"
+  "license": "(MIT OR GPL-3.0)"
 }


### PR DESCRIPTION
Greetings, jszip team! Thank for you for jszip! It has a lot to do with getting me stuck into JavaScript these past couple of years.

This small pull request takes npm up on [its recent decision to standardize license metadata on the SPDX standard](https://docs.npmjs.com/files/package.json#license) by using a full-blown license expression to code the dual license situation in machine-readable terms. This kind of thing should make it a lot easier to write tools that can both automate the drudgery of license checking and respect dual licensing scenarios.

Given how popular jszip is, I imagine this little change could save the community at large a lot of time and confusion.