### PR TITLE
Remove dist from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 _config.yml
 bower.json
 component.json
-dist
 docs
 documentation
 Gruntfile.js


### PR DESCRIPTION
Enable npm package for the browser since npm is a package manager for javascript, not just for node.