### PR TITLE
Add support of Array in JSZip#load.

### DIFF
--- a/documentation/api_jszip/load.md
+++ b/documentation/api_jszip/load.md
@@ -12,7 +12,7 @@ __Arguments__
 
 name               | type   | description
 -------------------|--------|------------
-data               | String/ArrayBuffer/Uint8Array/Buffer | the zip file
+data               | String/Array of bytes/ArrayBuffer/Uint8Array/Buffer | the zip file
 options            | object | the options to load the zip file
 
 Content of `options` :

--- a/lib/arrayReader.js
+++ b/lib/arrayReader.js
@@ -1,0 +1,50 @@
+'use strict';
+var DataReader = require('./dataReader');
+
+function ArrayReader(data) {
+    if (data) {
+        this.data = data;
+        this.length = this.data.length;
+        this.index = 0;
+
+        for(var i = 0; i < this.data.length; i++) {
+            data[i] = data[i] & 0xFF;
+        }
+    }
+}
+ArrayReader.prototype = new DataReader();
+/**
+ * @see DataReader.byteAt
+ */
+ArrayReader.prototype.byteAt = function(i) {
+    return this.data[i];
+};
+/**
+ * @see DataReader.lastIndexOfSignature
+ */
+ArrayReader.prototype.lastIndexOfSignature = function(sig) {
+    var sig0 = sig.charCodeAt(0),
+        sig1 = sig.charCodeAt(1),
+        sig2 = sig.charCodeAt(2),
+        sig3 = sig.charCodeAt(3);
+    for (var i = this.length - 4; i >= 0; --i) {
+        if (this.data[i] === sig0 && this.data[i + 1] === sig1 && this.data[i + 2] === sig2 && this.data[i + 3] === sig3) {
+            return i;
+        }
+    }
+
+    return -1;
+};
+/**
+ * @see DataReader.readData
+ */
+ArrayReader.prototype.readData = function(size) {
+    this.checkOffset(size);
+    if(size === 0) {
+        return [];
+    }
+    var result = this.data.slice(this.index, this.index + size);
+    this.index += size;
+    return result;
+};
+module.exports = ArrayReader;

--- a/lib/uint8ArrayReader.js
+++ b/lib/uint8ArrayReader.js
@@ -1,5 +1,5 @@
 'use strict';
-var DataReader = require('./dataReader');
+var ArrayReader = require('./arrayReader');
 
 function Uint8ArrayReader(data) {
     if (data) {
@@ -8,29 +8,7 @@ function Uint8ArrayReader(data) {
         this.index = 0;
     }
 }
-Uint8ArrayReader.prototype = new DataReader();
-/**
- * @see DataReader.byteAt
- */
-Uint8ArrayReader.prototype.byteAt = function(i) {
-    return this.data[i];
-};
-/**
- * @see DataReader.lastIndexOfSignature
- */
-Uint8ArrayReader.prototype.lastIndexOfSignature = function(sig) {
-    var sig0 = sig.charCodeAt(0),
-        sig1 = sig.charCodeAt(1),
-        sig2 = sig.charCodeAt(2),
-        sig3 = sig.charCodeAt(3);
-    for (var i = this.length - 4; i >= 0; --i) {
-        if (this.data[i] === sig0 && this.data[i + 1] === sig1 && this.data[i + 2] === sig2 && this.data[i + 3] === sig3) {
-            return i;
-        }
-    }
-
-    return -1;
-};
+Uint8ArrayReader.prototype = new ArrayReader();
 /**
  * @see DataReader.readData
  */

--- a/lib/zipEntries.js
+++ b/lib/zipEntries.js
@@ -2,6 +2,7 @@
 var StringReader = require('./stringReader');
 var NodeBufferReader = require('./nodeBufferReader');
 var Uint8ArrayReader = require('./uint8ArrayReader');
+var ArrayReader = require('./arrayReader');
 var utils = require('./utils');
 var sig = require('./signature');
 var ZipEntry = require('./zipEntry');
@@ -196,14 +197,19 @@ ZipEntries.prototype = {
     },
     prepareReader: function(data) {
         var type = utils.getTypeOf(data);
+        utils.checkSupport(type);
         if (type === "string" && !support.uint8array) {
             this.reader = new StringReader(data, this.loadOptions.optimizedBinaryString);
         }
         else if (type === "nodebuffer") {
             this.reader = new NodeBufferReader(data);
         }
-        else {
+        else if (support.uint8array) {
             this.reader = new Uint8ArrayReader(utils.transformTo("uint8array", data));
+        } else if (support.array) {
+            this.reader = new ArrayReader(utils.transformTo("array", data));
+        } else {
+            throw new Error("Unexpected error: unsupported type '" + type + "'");
         }
     },
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -1117,6 +1117,26 @@ testZipFile("load(string) handles bytes > 255", "ref/all.zip", function(file) {
    equal(zip.file("Hello.txt").asText(), "Hello World\n", "the zip was correctly read.");
 });
 
+testZipFile("load(Array) works", "ref/deflate.zip", function(file) {
+   var updatedFile = new Array(file.length);
+   for( var i = 0; i < file.length; ++i ) {
+      updatedFile[i] = file.charCodeAt(i) + 0x4200;
+   }
+   var zip = new JSZip(updatedFile);
+
+   equal(zip.file("Hello.txt").asText(), "This a looong file : we need to see the difference between the different compression methods.\n", "the zip was correctly read.");
+});
+
+testZipFile("load(array) handles bytes > 255", "ref/deflate.zip", function(file) {
+   var updatedFile = new Array(file.length);
+   for( var i = 0; i < file.length; ++i ) {
+      updatedFile[i] = file.charCodeAt(i) + 0x4200;
+   }
+   var zip = new JSZip(updatedFile);
+
+   equal(zip.file("Hello.txt").asText(), "This a looong file : we need to see the difference between the different compression methods.\n", "the zip was correctly read.");
+});
+
 if (JSZip.support.arraybuffer) {
    testZipFile("load(ArrayBuffer) works", "ref/all.zip", function(fileAsString) {
       var file = new ArrayBuffer(fileAsString.length);


### PR DESCRIPTION
In #250 case, we don't have fancy Uint8Array but we have an unsupported
binary format. An array of bytes (numbers between 0 and 255) is the
lowest common denominator. A binary string would awkward to build here
and building it reliably can be tricky (without filling the stack or
taking too much time/memory).
This commit adds the missing `arrayReader` needed here.