### PR TITLE
Improve browser testing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+ratings:
+   paths:
+   - "lib/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
-- '4.0'
-- '4.1'
+- '4.4'
+- 'stable'
 script: npm run $COMMAND
 sudo: false
 env:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,31 +5,51 @@ module.exports = function(grunt) {
       platform: "OS X 10.8",
       version: "6"
   }, {
+      browserName: "iphone",
+      platform: "OS X 10.10",
+      version: "9.2"
+  }, {
       browserName: "android",
       platform: "Linux",
       version: "4.0"
   }, {
+      browserName: "android",
+      platform: "Linux",
+      version: "4.4"
+  }, {
+      browserName: "android",
+      platform: "Linux",
+      version: "5.1"
+  }, {
       browserName: "firefox",
-      platform: "XP"
+      platform: "Windows 10"
   }, {
       browserName: "chrome",
-      platform: "XP"
+      platform: "Windows 10"
   }, {
       browserName: "internet explorer",
-      platform: "WIN8",
-      version: "10"
-  }, {
-      browserName: "internet explorer",
-      platform: "VISTA",
-      version: "9"
+      platform: "XP",
+      version: "7"
   }, {
       browserName: "internet explorer",
       platform: "Windows 7",
       version: "8"
   }, {
       browserName: "internet explorer",
-      platform: "XP",
-      version: "7"
+      platform: "Windows 7",
+      version: "9"
+  }, {
+      browserName: "internet explorer",
+      platform: "Windows 8",
+      version: "10"
+  }, {
+      browserName: "internet explorer",
+      platform: "Windows 10",
+      version: "11"
+  }, {
+      browserName: "edge",
+      platform: "Windows 10",
+      version: "13.10586"
   }, {
       browserName: "opera",
       platform: "Windows 2008",
@@ -38,6 +58,18 @@ module.exports = function(grunt) {
       browserName: "safari",
       platform: "OS X 10.8",
       version: "6"
+  }, {
+      browserName: "safari",
+      platform: "OS X 10.9",
+      version: "7"
+  }, {
+      browserName: "safari",
+      platform: "OS X 10.10",
+      version: "8"
+  }, {
+      browserName: "safari",
+      platform: "OS X 10.11",
+      version: "9"
   }];
 
   var tags = [];

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
       platform: "Windows 10",
       version: "11"
   }, {
-      browserName: "edge",
+      browserName: "microsoftedge",
       platform: "Windows 10",
       version: "13.10586"
   }, {

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,7 @@
-JSZip
+JSZip [![Build Status](https://api.travis-ci.org/Stuk/jszip.svg?branch=master)](http://travis-ci.org/Stuk/jszip) [![Code Climate](https://codeclimate.com/github/Stuk/jszip/badges/gpa.svg)](https://codeclimate.com/github/Stuk/jszip)
+
+[![Selenium Test Status](https://saucelabs.com/browser-matrix/jszip.svg)](https://saucelabs.com/u/jszip)
+
 =====
 
 A library for creating, reading and editing .zip files with Javascript, with a
@@ -26,14 +29,6 @@ images/
     smile.gif
 */
 ```
-
-Test status
------------
-
-[![Build Status](https://api.travis-ci.org/Stuk/jszip.svg?branch=master)](http://travis-ci.org/Stuk/jszip)
-
-[![Selenium Test Status](https://saucelabs.com/browser-matrix/jszip.svg)](https://saucelabs.com/u/jszip)
-
 License
 -------
 

--- a/README.markdown
+++ b/README.markdown
@@ -3,8 +3,6 @@ JSZip [![Build Status](https://api.travis-ci.org/Stuk/jszip.svg?branch=master)](
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/jszip.svg)](https://saucelabs.com/u/jszip)
 
-=====
-
 A library for creating, reading and editing .zip files with Javascript, with a
 lovely and simple API.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,5 @@
 JSZip [![Build Status](https://api.travis-ci.org/Stuk/jszip.svg?branch=master)](http://travis-ci.org/Stuk/jszip) [![Code Climate](https://codeclimate.com/github/Stuk/jszip/badges/gpa.svg)](https://codeclimate.com/github/Stuk/jszip)
+=====
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/jszip.svg)](https://saucelabs.com/u/jszip)
 


### PR DESCRIPTION
I've updated the selection of browser on which the libraries is tested.

index.html should be probably updated.

It is important nowadays to asses that the library is functiioning on IE11, Edge, and latest Android / Iphone that are all missing.

I would be a nice to have to start assessing also the code coverage of the tests exectuted on the library, and this would allow to spot deadbranches and outdated code.

