### PR TITLE
[breaking change] JSZip v3: drop node 0.8 support.

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@ zip.generateAsync({type:"blob"})
     <td>Tested with the latest version</td>
     <td>Tested with the latest version</td>
     <td>Tested with IE 6 / 7 / 8 / 9 / 10</td>
-    <td>Tested with node.js 0.8 and 0.10</td>
+    <td>Tested with node.js 0.10 / latest version</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Since nodejs 0.10.26 (npm 1.4.3), the default when doing a `npm install --save`
is to use caret ranges (`^1.2.3`). It is now nearly impossible to use
nodejs 0.8 with recent version of libs because of this: if a transitive
dependency uses a caret, we get a "No compatible version found" error.

We can't use Travis to test nodejs 0.8: because of these dependencies,
the `npm install` phase failed.
From [here][0], nodejs 0.10 still has a lot of users while nodejs 0.8
doesn't even appears on the chart.

[0]: https://semaphoreci.com/blog/2015/12/15/nodejs-version-usage-in-commercial-projects-2015-edition.html