### PR TITLE
Fix the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       env: COMMAND=test-node
     - node_js: "stable"
       env: COMMAND=test-browser
+env:
   global:
   - secure: MhA8GHU42X3GWTUMaqdZVvarx4BMjhQCUGNi3kvuD/iCmKVb7gMwj4jbds7AcJdsCRsRk8bBGzZs/E7HidBJMPDa5DhgLKy9EV1s42JlHq8lVzbJeWIGgrtyJvhVUkGRy2OJjnDSgh3U6elkQmvDn74jreSQc6m/yGoPFF1nqq8=
   - secure: qREw6aUu2DnB+2reMuHgygSkumRiJvt7Z5Fz4uEVoraqbe65e4PGhtzypr9uIgCN43vxS2D5tAIeDbfid5VQrWFUQnrC9O5Z5qgVPsKN94zZ1tvYurXI4wRlAg58nNjkfGXWhLI3VUjjDTp5gYcMqgfe5hpEFYUPnUQkKGnaqAk=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,7 @@ module.exports = function(grunt) {
                   urls: ["http://127.0.0.1:9999/test/index.html"],
                   tunnelTimeout: 5,
                   build: process.env.TRAVIS_JOB_ID,
-                  concurrency: 3,
+                  throttled: 3,
                   browsers: browsers,
                   testname: "qunit tests",
                   tags: tags


### PR DESCRIPTION
In #273, the global secure variables went from env.matrix to
matrix.include. Now, when travis launches the `test-browser` step, it
can't find these variables (SAUCE_USERNAME and SAUCE_ACCESS_KEY) and
stops.
This commit fix the scope to use saucelabs again.