### PR TITLE
[JSZip v3] Blob, Promise and more.

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,1 @@
 node_modules
-test

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,11 @@
 {
+    "curly": true,
+    "eqeqeq": true,
+    "nonew": true,
+    "noarg": true,
+    "forin": true,
+    "futurehostile": true,
+    "freeze": true,
     "undef": true,
     "strict": true,
     "sub": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,11 +107,27 @@ module.exports = function(grunt) {
           }
       },
       jshint: {
-            options: {
-                jshintrc: "./.jshintrc"
-            },
-            all: ['./lib/**/*.js', './test/helpers/**/*.js', './test/asserts/**/*.js']
-        },
+          // see https://github.com/gruntjs/grunt-contrib-jshint/issues/198
+          // we can't override the options using the jshintrc path
+          options: grunt.file.readJSON('.jshintrc'),
+          production: ['./lib/**/*.js'],
+          test: ['./test/helpers/**/*.js', './test/asserts/**/*.js'],
+          documentation: {
+              options: {
+                  globals: {
+                      jQuery: false,
+                      JSZip: false,
+                      JSZipUtils: false,
+                      saveAs: false
+                  },
+                  // implied still give false positives in our case
+                  strict: false
+              },
+              files: {
+                  src: ['./documentation/**/*.js']
+              }
+          }
+      },
     browserify: {
       all: {
         files: {

--- a/documentation/api_jszip/external.md
+++ b/documentation/api_jszip/external.md
@@ -6,7 +6,17 @@ section: api
 
 JSZip uses polyfills of objects that may not exist on every platform.
 Accessing or replacing these objects can sometimes be useful. JSZip.external
-It contains the following properties :
+contains the following properties :
 
-* `Promise` : the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) used.
+* `Promise` : the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) implementation used.
+
+__Example__
+
+```js
+// use bluebird instead
+JSZip.external.Promise = Bluebird;
+
+// use the native Promise object:
+JSZip.external.Promise = Promise;
+```
 

--- a/documentation/api_jszip/file_data.md
+++ b/documentation/api_jszip/file_data.md
@@ -11,7 +11,7 @@ __Arguments__
 name                | type    | description
 --------------------|---------|------------
 name                | string  | the name of the file. You can specify folders in the name : the folder separator is a forward slash ("/").
-data                | String/ArrayBuffer/Uint8Array/Buffer | the content of the file.
+data                | String/ArrayBuffer/Uint8Array/Buffer/Blob/Promise | the content of the file.
 options             | object  | the options.
 
 Content of `options` :
@@ -51,7 +51,8 @@ as a folder and the content will be ignored.
 
 __Returns__ : The current JSZip object, for chaining.
 
-__Throws__ : An exception if the data is not in a supported format.
+__Throws__ : Nothing. (an exception will be propagated if the data is not in
+a supported format).
 
 <!--
 __Complexity__ : **O(1)** for anything but binary strings.

--- a/documentation/api_jszip/load_async.md
+++ b/documentation/api_jszip/load_async.md
@@ -12,7 +12,7 @@ __Arguments__
 
 name               | type   | description
 -------------------|--------|------------
-data               | String/Array of bytes/ArrayBuffer/Uint8Array/Buffer | the zip file
+data               | String/Array of bytes/ArrayBuffer/Uint8Array/Buffer/Blob/Promise | the zip file
 options            | object | the options to load the zip file
 
 Content of `options` :

--- a/documentation/api_zipobject/async.md
+++ b/documentation/api_zipobject/async.md
@@ -10,7 +10,7 @@ __Arguments__
 
 name     | type     | description
 ---------|----------|------------
-type     | String   | the type of the result : `string` (or `text`, its alias), `binarystring`, `base64`, `uint8array`, `arraybuffer`, `nodebuffer`.
+type     | String   | the type of the result : `string` (or `text`, its alias), `binarystring`, `base64`, `array`, `uint8array`, `arraybuffer`, `nodebuffer`.
 onUpdate | Function | an optional function called on each internal update with the metadata.
 
 __Metadata__ : the metadata are :

--- a/documentation/examples/get-binary-files-ajax.html
+++ b/documentation/examples/get-binary-files-ajax.html
@@ -9,6 +9,9 @@ section: example
 <h3>With JSZipUtils</h3>
 <div id="jszip_utils"></div>
 
+<h3>With the Fetch API</h3>
+<div id="fetch"></div>
+
 <script type="text/javascript">
 (function () {
 
@@ -16,8 +19,8 @@ section: example
     elt.innerHTML = "<p class='alert alert-danger'>" + err + "</p>";
   }
 
-  function showContent(elt, type, content) {
-    elt.innerHTML = "<p class='alert alert-success'>loaded ! (as a " + type + ")<br/>" +
+  function showContent(elt, content) {
+    elt.innerHTML = "<p class='alert alert-success'>loaded !<br/>" +
       "Content = " + content + "</p>";
   }
 
@@ -37,7 +40,7 @@ section: example
         return zip.file("Hello.txt").async("string");
       })
       .then(function success(text) {
-        showContent(elt, "" + data, text);
+        showContent(elt, text);
       }, function error(e) {
         showError(elt, e);
       });
@@ -45,6 +48,34 @@ section: example
       showError(elt, e);
     }
   });
+
+  //=========================
+  // Fetch API
+  //=========================
+  (function () {
+    var elt = document.getElementById('fetch');
+    if(typeof window.fetch === "function") {
+      fetch('{{site.baseurl}}/test/ref/text.zip')
+      .then(function (response) {
+        if (response.status === 200 || response.status === 0) {
+          return Promise.resolve(response.arrayBuffer())
+        } else {
+          return Promise.reject(new Error(response.statusText))
+        }
+      })
+      .then(JSZip.loadAsync)
+      .then(function (zip) {
+        return zip.file("Hello.txt").async("string");
+      })
+      .then(function success(text) {
+        showContent(elt, text);
+      }, function error(e) {
+        showError(elt, e);
+      });
+    } else {
+      showError(elt, "This browser doesn't support the Fetch API.");
+    } 
+  })();
 
 })();
 </script>

--- a/documentation/examples/read-local-file-api.html
+++ b/documentation/examples/read-local-file-api.html
@@ -32,56 +32,40 @@ section: example
     // be sure to show the results
     $("#result_block").removeClass("hidden").addClass("show");
 
-    // see http://www.html5rocks.com/en/tutorials/file/dndfiles/
+    // Closure to capture the file information.
+    function handleFile(f) {
+      var $title = $("<h4>", {
+        text : f.name
+      });
+      var $fileContent = $("<ul>");
+      $result.append($title);
+      $result.append($fileContent);
+    
+      var dateBefore = new Date();
+      JSZip.loadAsync(f)
+      .then(function(zip) {
+        var dateAfter = new Date();
+        $title.append($("<span>", {
+          text:" (loaded in " + (dateAfter - dateBefore) + "ms)"
+        }));
+
+
+        zip.forEach(function (relativePath, zipEntry) {
+          $fileContent.append($("<li>", {
+            text : zipEntry.name
+          }));
+        });
+      }, function (e) {
+        $fileContent = $("<div>", {
+          "class" : "alert alert-danger",
+          text : "Error reading " + f.name + " : " + e.message
+        });
+      });
+    }
 
     var files = evt.target.files;
     for (var i = 0, f; f = files[i]; i++) {
-
-      var reader = new FileReader();
-
-      // Closure to capture the file information.
-      reader.onload = (function(theFile) {
-        return function(e) {
-          var $title = $("<h4>", {
-            text : theFile.name
-          });
-          $result.append($title);
-          var $fileContent = $("<ul>");
-          try {
-
-            var dateBefore = new Date();
-            // read the content of the file with JSZip
-            JSZip.loadAsync(e.target.result)
-            .then(function(zip) {
-              var dateAfter = new Date();
-
-              $title.append($("<span>", {
-                  text:" (parsed in " + (dateAfter - dateBefore) + "ms)"
-              }));
-
-              zip.forEach(function (relativePath, zipEntry) {
-                $fileContent.append($("<li>", {
-                    text : zipEntry.name
-                }));
-                // the content is here : zipEntry.async("string")
-              });
-            });
-            // end of the magic !
-
-          } catch(e) {
-            $fileContent = $("<div>", {
-              "class" : "alert alert-danger",
-              text : "Error reading " + theFile.name + " : " + e.message
-            });
-          }
-          $result.append($fileContent);
-        }
-      })(f);
-
-      // read the file !
-      // readAsArrayBuffer and readAsBinaryString both produce valid content for JSZip.
-      reader.readAsArrayBuffer(f);
-      // reader.readAsBinaryString(f);
+        handleFile(f);
     }
   });
 })();

--- a/documentation/howto/read_zip.md
+++ b/documentation/howto/read_zip.md
@@ -112,15 +112,12 @@ var req = http.get(url.parse("http://localhost/.../file.zip"), function (res) {
   });
 
   res.on("end", function () {
-    var buf = new Buffer(dataLen);
-    for (var i=0,len=data.length,pos=0; i<len; i++) {
-      data[i].copy(buf, pos);
-      pos += data[i].length;
-    }
+    var buf = Buffer.concat(data);
 
     // here we go !
-    var zip = new JSZip(buf);
-    zip.file("content.txt").async("string").then(function (text) {
+    JSZip.loadAsync(buf).then(function (zip) {
+      return zip.file("content.txt").async("string");
+    }).then(function (text) {
       console.log(text);
     });
   });
@@ -148,8 +145,9 @@ request({
     // handle error
     return;
   }
-  var zip = new JSZip(body);
-  zip.file("content.txt").async("string").then(function (text) {
+  JSZip.loadAsync(body).then(function (zip) {
+    return zip.file("content.txt").async("string");
+  }).then(function () {
     console.log(text);
   });
 });

--- a/documentation/upgrade_guide.md
+++ b/documentation/upgrade_guide.md
@@ -9,7 +9,7 @@ section: main
 * Deprecated objects/methods has been removed:
   * `options.base64` in `generate()` (the base64 type is still valid)
   * `options.base64`, `options.binary`, `options.dir`, `options.date`
-    on `ZipObject` (see the [2.3 upgrade section](#from-2.2.2-to-2.3.0))
+    on `ZipObject` (see the [2.3 upgrade section](#from-222-to-230))
   * `JSZip.utils`
   * `JSZip.prototype.crc32`, `JSZip.prototype.utf8encode`, `JSZip.prototype.utf8decode`
   * `JSZip.base64` (you can get the content of a file directly as a base64 string)

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -72,10 +72,10 @@ exports.decode = function(input) {
 
         output[resultIndex++] = chr1;
 
-        if (enc3 != 64) {
+        if (enc3 !== 64) {
             output[resultIndex++] = chr2;
         }
-        if (enc4 != 64) {
+        if (enc4 !== 64) {
             output[resultIndex++] = chr3;
         }
 

--- a/lib/compressedObject.js
+++ b/lib/compressedObject.js
@@ -35,7 +35,7 @@ CompressedObject.prototype = {
 
         var that = this;
         worker.on("end", function () {
-            if(this.streamInfo['data_length'] != that.uncompressedSize) {
+            if(this.streamInfo['data_length'] !== that.uncompressedSize) {
                 throw new Error("Bug : uncompressed data size mismatch");
             }
         });

--- a/lib/compressedObject.js
+++ b/lib/compressedObject.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ES6Promise = require("./external").Promise;
+var external = require("./external");
 var DataWorker = require('./stream/DataWorker');
 var DataLengthProbe = require('./stream/DataLengthProbe');
 var Crc32Probe = require('./stream/Crc32Probe');
@@ -29,7 +29,7 @@ CompressedObject.prototype = {
      * @return {GenericWorker} the worker.
      */
     getContentWorker : function () {
-        var worker = new DataWorker(ES6Promise.resolve(this.compressedContent))
+        var worker = new DataWorker(external.Promise.resolve(this.compressedContent))
         .pipe(this.compression.uncompressWorker())
         .pipe(new DataLengthProbe("data_length"));
 
@@ -46,7 +46,7 @@ CompressedObject.prototype = {
      * @return {GenericWorker} the worker.
      */
     getCompressedWorker : function () {
-        return new DataWorker(ES6Promise.resolve(this.compressedContent))
+        return new DataWorker(external.Promise.resolve(this.compressedContent))
         .withStreamInfo("compressedSize", this.compressedSize)
         .withStreamInfo("uncompressedSize", this.uncompressedSize)
         .withStreamInfo("crc32", this.crc32)

--- a/lib/compressedObject.js
+++ b/lib/compressedObject.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var ES6Promise = require("./external").Promise;
 var DataWorker = require('./stream/DataWorker');
 var DataLengthProbe = require('./stream/DataLengthProbe');
 var Crc32Probe = require('./stream/Crc32Probe');
@@ -28,7 +29,7 @@ CompressedObject.prototype = {
      * @return {GenericWorker} the worker.
      */
     getContentWorker : function () {
-        var worker = new DataWorker(this.compressedContent)
+        var worker = new DataWorker(ES6Promise.resolve(this.compressedContent))
         .pipe(this.compression.uncompressWorker())
         .pipe(new DataLengthProbe("data_length"));
 
@@ -45,7 +46,7 @@ CompressedObject.prototype = {
      * @return {GenericWorker} the worker.
      */
     getCompressedWorker : function () {
-        return new DataWorker(this.compressedContent)
+        return new DataWorker(ES6Promise.resolve(this.compressedContent))
         .withStreamInfo("compressedSize", this.compressedSize)
         .withStreamInfo("uncompressedSize", this.uncompressedSize)
         .withStreamInfo("crc32", this.crc32)

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,6 +1,6 @@
 'use strict';
 var utils = require('./utils');
-var ES6Promise = require("./external").Promise;
+var external = require("./external");
 var utf8 = require('./utf8');
 var utils = require('./utils');
 var ZipEntries = require('./zipEntries');
@@ -12,7 +12,7 @@ var Crc32Probe = require('./stream/Crc32Probe');
  * @return {Promise} the result.
  */
 function checkEntryCRC32(zipEntry) {
-    return new ES6Promise(function (resolve, reject) {
+    return new external.Promise(function (resolve, reject) {
         var worker = zipEntry.decompressed.getContentWorker().pipe(new Crc32Probe());
         worker.on("error", function (e) {
             reject(e);
@@ -44,14 +44,14 @@ module.exports = function(data, options) {
         zipEntries.load(data);
         return zipEntries;
     }).then(function checkCRC32(zipEntries) {
-        var promises = [ES6Promise.resolve(zipEntries)];
+        var promises = [external.Promise.resolve(zipEntries)];
         var files = zipEntries.files;
         if (options.checkCRC32) {
             for (var i = 0; i < files.length; i++) {
                 promises.push(checkEntryCRC32(files[i]));
             }
         }
-        return ES6Promise.all(promises);
+        return external.Promise.all(promises);
     }).then(function addFiles(results) {
         var zipEntries = results.shift();
         var files = zipEntries.files;

--- a/lib/load.js
+++ b/lib/load.js
@@ -5,6 +5,7 @@ var utf8 = require('./utf8');
 var utils = require('./utils');
 var ZipEntries = require('./zipEntries');
 var Crc32Probe = require('./stream/Crc32Probe');
+var nodejsUtils = require("./nodejsUtils");
 
 /**
  * Check the CRC32 of an entry.
@@ -37,6 +38,10 @@ module.exports = function(data, options) {
         createFolders: false,
         decodeFileName: utf8.utf8decode
     });
+
+    if (nodejsUtils.isNode && nodejsUtils.isStream(data)) {
+        return external.Promise.reject(new Error("JSZip can't accept a stream when loading a zip file."));
+    }
 
     return utils.prepareContent("the loaded zip file", data, true, options.optimizedBinaryString, options.base64)
     .then(function(data) {

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,5 +1,5 @@
 'use strict';
-var base64 = require('./base64');
+var utils = require('./utils');
 var ES6Promise = require("./external").Promise;
 var utf8 = require('./utf8');
 var utils = require('./utils');
@@ -37,13 +37,12 @@ module.exports = function(data, options) {
         createFolders: false,
         decodeFileName: utf8.utf8decode
     });
-    return new ES6Promise(function loadEntries(resolve, reject) {
-        if (options.base64) {
-            data = base64.decode(data);
-        }
+
+    return utils.prepareContent("the loaded zip file", data, true, options.optimizedBinaryString, options.base64)
+    .then(function(data) {
         var zipEntries = new ZipEntries(options);
         zipEntries.load(data);
-        resolve(zipEntries);
+        return zipEntries;
     }).then(function checkCRC32(zipEntries) {
         var promises = [ES6Promise.resolve(zipEntries)];
         var files = zipEntries.files;

--- a/lib/object.js
+++ b/lib/object.js
@@ -3,7 +3,6 @@ var utf8 = require('./utf8');
 var utils = require('./utils');
 var GenericWorker = require('./stream/GenericWorker');
 var StreamHelper = require('./stream/StreamHelper');
-var base64 = require('./base64');
 var defaults = require('./defaults');
 var CompressedObject = require('./compressedObject');
 var ZipObject = require('./zipObject');
@@ -11,24 +10,6 @@ var generate = require("./generate");
 var nodejsUtils = require("./nodejsUtils");
 var NodejsStreamInputAdapter = require("./nodejs/NodejsStreamInputAdapter");
 
-/**
- * Transforms the (incomplete) options from the user into the complete
- * set of options to create a file.
- * @private
- * @param {Object} o the options from the user.
- * @return {Object} the complete set of options.
- */
-var prepareFileAttrs = function(o) {
-    o = o || {};
-    if (o.base64 === true && (o.binary === null || o.binary === undefined)) {
-        o.binary = true;
-    }
-    o = utils.extend(o, defaults);
-    o.date = o.date || new Date();
-    if (o.compression !== null) o.compression = o.compression.toUpperCase();
-
-    return o;
-};
 
 /**
  * Add a file in the current folder.
@@ -43,7 +24,16 @@ var fileAdd = function(name, data, o) {
     var dataType = utils.getTypeOf(data),
         parent;
 
-    o = prepareFileAttrs(o);
+
+    /*
+     * Correct options.
+     */
+
+    o = utils.extend(o || {}, defaults);
+    o.date = o.date || new Date();
+    if (o.compression !== null) {
+        o.compression = o.compression.toUpperCase();
+    }
 
     if (typeof o.unixPermissions === "string") {
         o.unixPermissions = parseInt(o.unixPermissions, 8);
@@ -61,57 +51,51 @@ var fileAdd = function(name, data, o) {
     if (o.dir) {
         name = forceTrailingSlash(name);
     }
-
-    // special case : it's way easier to work with Uint8Array than with ArrayBuffer
-    if (dataType === "arraybuffer") {
-        data = utils.transformTo("uint8array", data);
-    }
-    if (nodejsUtils.isNode && nodejsUtils.isStream(data)) {
-        data = new NodejsStreamInputAdapter(name, data);
-    }
-
     if (o.createFolders && (parent = parentFolder(name))) {
         folderAdd.call(this, parent, true);
     }
+
+    var isUnicodeString = dataType === "string" && o.binary === false && o.base64 === false;
+    o.binary = !isUnicodeString;
+
 
     var isCompressedEmpty = (data instanceof CompressedObject) && data.uncompressedSize === 0;
 
     if (isCompressedEmpty || o.dir || !data || data.length === 0) {
         o.base64 = false;
         o.binary = true;
-        data = null;
+        data = "";
         o.compression = "STORE";
-        dataType = null;
-    }
-    else if (
-        !dataType &&
-        !(data instanceof CompressedObject) &&
-        !(data instanceof GenericWorker)) {
-        throw new Error("The data of '" + name + "' is in an unsupported format !");
-    }
-    else if (dataType === "string") {
-        if (o.base64) {
-            data = base64.decode(data);
-            o.base64 = false;
-            o.binary = true;
-        }
-        else if (o.binary) {
-            // optimizedBinaryString === true means that the file has already been filtered with a 0xFF mask
-            if (o.optimizedBinaryString !== true) {
-                // this is a string, not in a base64 format.
-                // Be sure that this is a correct "binary string"
-                data = utils.string2binary(data);
-            }
-        }
-    }
-    else { // arraybuffer, uint8array, ...
-        o.base64 = false;
-        o.binary = true;
+        dataType = "string";
     }
 
-    var object = new ZipObject(name, data, o);
+    /*
+     * Convert content to fit.
+     */
+
+    var zipObjectContent = null;
+    if (data instanceof CompressedObject || data instanceof GenericWorker) {
+        zipObjectContent = data;
+    } else if (nodejsUtils.isNode && nodejsUtils.isStream(data)) {
+        zipObjectContent = new NodejsStreamInputAdapter(name, data);
+    } else {
+        zipObjectContent = utils.prepareContent(name, data, o.binary, o.optimizedBinaryString, o.base64);
+    }
+
+    var object = new ZipObject(name, zipObjectContent, o);
     this.files[name] = object;
-    return object;
+    /*
+    TODO: we can't throw an exception because we have async promises
+    (we can have a promise of a Date() for example) but returning a
+    promise is useless because file(name, data) returns the JSZip
+    object for chaining. Should we break that to allow the user
+    to catch the error ?
+
+    return ES6Promise.resolve(zipObjectContent)
+    .then(function () {
+        return object;
+    });
+    */
 };
 
 /**
@@ -164,6 +148,16 @@ var folderAdd = function(name, createFolders) {
     }
     return this.files[name];
 };
+
+/**
+* Cross-window, cross-Node-context regular expression detection
+* @param  {Object}  object Anything
+* @return {Boolean}        true if the object is a regular expression,
+* false otherwise
+*/
+function isRegExp(object) {
+    return Object.prototype.toString.call(object) === "[object RegExp]";
+}
 
 // return the actual prototype of JSZip
 var out = {
@@ -224,7 +218,7 @@ var out = {
      */
     file: function(name, data, o) {
         if (arguments.length === 1) {
-            if (utils.isRegExp(name)) {
+            if (isRegExp(name)) {
                 var regexp = name;
                 return this.filter(function(relativePath, file) {
                     return !file.dir && regexp.test(relativePath);
@@ -256,7 +250,7 @@ var out = {
             return this;
         }
 
-        if (utils.isRegExp(arg)) {
+        if (isRegExp(arg)) {
             return this.filter(function(relativePath, file) {
                 return file.dir && arg.test(relativePath);
             });

--- a/lib/object.js
+++ b/lib/object.js
@@ -91,7 +91,7 @@ var fileAdd = function(name, data, o) {
     object for chaining. Should we break that to allow the user
     to catch the error ?
 
-    return ES6Promise.resolve(zipObjectContent)
+    return external.Promise.resolve(zipObjectContent)
     .then(function () {
         return object;
     });

--- a/lib/reader/StringReader.js
+++ b/lib/reader/StringReader.js
@@ -2,11 +2,8 @@
 var DataReader = require('./DataReader');
 var utils = require('../utils');
 
-function StringReader(data, optimizedBinaryString) {
+function StringReader(data) {
     DataReader.call(this, data);
-    if (!optimizedBinaryString) {
-        this.data = utils.string2binary(this.data);
-    }
 }
 utils.inherits(StringReader, DataReader);
 /**

--- a/lib/reader/readerFor.js
+++ b/lib/reader/readerFor.js
@@ -10,14 +10,13 @@ var Uint8ArrayReader = require('./Uint8ArrayReader');
 /**
  * Create a reader adapted to the data.
  * @param {String|ArrayBuffer|Uint8Array|Buffer} data the data to read.
- * @param {boolean} optimizedBinaryString true if the data is a binary string, false otherwise.
  * @return {DataReader} the data reader.
  */
-module.exports = function (data, optimizedBinaryString) {
+module.exports = function (data) {
     var type = utils.getTypeOf(data);
     utils.checkSupport(type);
     if (type === "string" && !support.uint8array) {
-        return new StringReader(data, optimizedBinaryString);
+        return new StringReader(data);
     }
     if (type === "nodebuffer") {
         return new NodeBufferReader(data);

--- a/lib/stream/DataWorker.js
+++ b/lib/stream/DataWorker.js
@@ -10,18 +10,30 @@ var DEFAULT_BLOCK_SIZE = 16 * 1024;
 /**
  * A worker that reads a content and emits chunks.
  * @constructor
- * @param {String|ArrayBuffer|Uint8Array|Buffer} data the data to split
+ * @param {Promise} dataP the promise of the data to split
  */
-function DataWorker(data) {
-    var dataType = utils.getTypeOf(data);
-    GenericWorker.call(this, "DataWorker for " + dataType);
-
+function DataWorker(dataP) {
+    GenericWorker.call(this, "DataWorker");
+    var self = this;
+    this.dataIsReady = false;
     this.index = 0;
-    this.max = data && data.length || 0;
-    this.data = data;
-    this.type = dataType;
+    this.max = 0;
+    this.data = null;
+    this.type = "";
 
     this._tickScheduled = false;
+
+    dataP.then(function (data) {
+        self.dataIsReady = true;
+        self.data = data;
+        self.max = data && data.length || 0;
+        self.type = utils.getTypeOf(data);
+        if(!self.isPaused) {
+            self._tickAndRepeat();
+        }
+    }, function (e) {
+        self.error(e);
+    });
 }
 
 utils.inherits(DataWorker, GenericWorker);
@@ -42,7 +54,7 @@ DataWorker.prototype.resume = function () {
         return false;
     }
 
-    if (!this._tickScheduled) {
+    if (!this._tickScheduled && this.dataIsReady) {
         this._tickScheduled = true;
         utils.delay(this._tickAndRepeat, [], this);
     }
@@ -54,7 +66,7 @@ DataWorker.prototype.resume = function () {
  */
 DataWorker.prototype._tickAndRepeat = function() {
     this._tickScheduled = false;
-    if(this.isFinished) {
+    if(this.isPaused || this.isFinished) {
         return;
     }
     this._tick();

--- a/lib/stream/StreamHelper.js
+++ b/lib/stream/StreamHelper.js
@@ -5,7 +5,7 @@ var ConvertWorker = require('./ConvertWorker');
 var GenericWorker = require('./GenericWorker');
 var base64 = require('../base64');
 var NodejsStreamOutputAdapter = require('../nodejs/NodejsStreamOutputAdapter');
-var ES6Promise = require("../external").Promise;
+var external = require("../external");
 
 /**
  * Apply the final transformation of the data. If the user wants a Blob for
@@ -66,7 +66,7 @@ function concat (type, dataArray) {
  * @return Promise the promise for the accumulation.
  */
 function accumulate(helper, updateCallback) {
-    return new ES6Promise(function (resolve, reject){
+    return new external.Promise(function (resolve, reject){
         var dataArray = [];
         var chunkType = helper._internalType,
             resultType = helper._outputType,

--- a/lib/stream/StreamHelper.js
+++ b/lib/stream/StreamHelper.js
@@ -42,6 +42,8 @@ function concat (type, dataArray) {
     switch(type) {
         case "string":
             return dataArray.join("");
+          case "array":
+            return Array.prototype.concat.apply([], dataArray);
         case "uint8array":
             res = new Uint8Array(totalLength);
             for(i = 0; i < dataArray.length; i++) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,21 +1,28 @@
 'use strict';
 
 var support = require('./support');
+var base64 = require('./base64');
 var nodejsUtils = require('./nodejsUtils');
 var asap = require('asap');
+var ES6Promise = require("./external").Promise;
+
 
 /**
- * Convert a string to a "binary string" : a string containing only char codes between 0 and 255.
- * @param {string} str the string to transform.
- * @return {String} the binary string.
+ * Convert a string that pass as a "binary string": it should represent a byte
+ * array but may have > 255 char codes. Be sure to take only the first byte
+ * and returns the byte array.
+ * @param {String} str the string to transform.
+ * @return {Array|Uint8Array} the string in a binary format.
  */
-exports.string2binary = function(str) {
-    var result = "";
-    for (var i = 0; i < str.length; i++) {
-        result += String.fromCharCode(str.charCodeAt(i) & 0xff);
+function string2binary(str) {
+    var result = null;
+    if (support.uint8array) {
+      result = new Uint8Array(str.length);
+    } else {
+      result = new Array(str.length);
     }
-    return result;
-};
+    return stringToArrayLike(str, result);
+}
 
 /**
  * Create a new blob with the given content and the given type.
@@ -360,16 +367,6 @@ exports.pretty = function(str) {
 };
 
 /**
-* Cross-window, cross-Node-context regular expression detection
-* @param  {Object}  object Anything
-* @return {Boolean}        true if the object is a regular expression,
-* false otherwise
-*/
-exports.isRegExp = function (object) {
-    return Object.prototype.toString.call(object) === "[object RegExp]";
-};
-
-/**
  * Defer the call of a function.
  * @param {Function} callback the function to call asynchronously.
  * @param {Array} args the arguments to give to the callback.
@@ -410,3 +407,59 @@ exports.extend = function() {
     return result;
 };
 
+/**
+ * Transform arbitrary content into a Promise.
+ * @param {String} name a name for the content being processed.
+ * @param {Object} inputData the content to process.
+ * @param {Boolean} isBinary true if the content is not an unicode string
+ * @param {Boolean} isOptimizedBinaryString true if the string content only has one byte per character.
+ * @param {Boolean} isBase64 true if the string content is encoded with base64.
+ * @return {Promise} a promise in a format usable by JSZip.
+ */
+exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinaryString, isBase64) {
+
+    var promise = null;
+    if (support.blob && inputData instanceof Blob && typeof FileReader !== "undefined") {
+        promise = new ES6Promise(function (resolve, reject) {
+            var reader = new FileReader();
+
+            reader.onload = function(e) {
+                resolve(e.target.result);
+            };
+            reader.onerror = function(e) {
+                reject(e.target.error);
+            };
+            reader.readAsArrayBuffer(inputData);
+        });
+    } else {
+        // if data is already a promise, this flatten it.
+        promise = ES6Promise.resolve(inputData);
+    }
+
+    return promise.then(function(data) {
+        var dataType = exports.getTypeOf(data);
+
+        if (!dataType) {
+            return ES6Promise.reject(
+                new Error("The data of '" + name + "' is in an unsupported format !")
+            );
+        }
+        // special case : it's way easier to work with Uint8Array than with ArrayBuffer
+        if (dataType === "arraybuffer") {
+            data = exports.transformTo("uint8array", data);
+        } else if (dataType === "string") {
+            if (isBase64) {
+                data = base64.decode(data);
+            }
+            else if (isBinary) {
+                // optimizedBinaryString === true means that the file has already been filtered with a 0xFF mask
+                if (isOptimizedBinaryString !== true) {
+                    // this is a string, not in a base64 format.
+                    // Be sure that this is a correct "binary string"
+                    data = string2binary(data);
+                }
+            }
+        }
+        return data;
+    });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ var support = require('./support');
 var base64 = require('./base64');
 var nodejsUtils = require('./nodejsUtils');
 var asap = require('asap');
-var ES6Promise = require("./external").Promise;
+var external = require("./external");
 
 
 /**
@@ -420,7 +420,7 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
 
     var promise = null;
     if (support.blob && inputData instanceof Blob && typeof FileReader !== "undefined") {
-        promise = new ES6Promise(function (resolve, reject) {
+        promise = new external.Promise(function (resolve, reject) {
             var reader = new FileReader();
 
             reader.onload = function(e) {
@@ -433,14 +433,14 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
         });
     } else {
         // if data is already a promise, this flatten it.
-        promise = ES6Promise.resolve(inputData);
+        promise = external.Promise.resolve(inputData);
     }
 
     return promise.then(function(data) {
         var dataType = exports.getTypeOf(data);
 
         if (!dataType) {
-            return ES6Promise.reject(
+            return external.Promise.reject(
                 new Error("The data of '" + name + "' is in an unsupported format !")
             );
         }

--- a/lib/zipEntries.js
+++ b/lib/zipEntries.js
@@ -245,7 +245,7 @@ ZipEntries.prototype = {
         }
     },
     prepareReader: function(data) {
-        this.reader = readerFor(data, this.loadOptions.optimizedBinaryString);
+        this.reader = readerFor(data);
     },
     /**
      * Read a zip file and create ZipEntries.

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   ],
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.9",
-    "grunt-saucelabs": "~8.6.1",
-    "grunt-contrib-connect": "~1.0.0",
+    "grunt-cli": "~1.1.0",
+    "grunt-saucelabs": "~8.6.2",
+    "grunt-contrib-connect": "1.0.0",
     "jshint": "~2.9.1",
     "browserify": "~13.0.0",
     "grunt-browserify": "~5.0.0",
@@ -45,7 +45,7 @@
     "grunt-contrib-uglify": "~1.0.0",
     "jszip-utils": "~0.0.2",
     "qunit-cli": "~0.2.0",
-    "qunitjs": "~1.22.0",
+    "qunitjs": "~1.23.0",
     "tmp": "0.0.28"
   },
   "dependencies": {

--- a/test/asserts/deprecated.js
+++ b/test/asserts/deprecated.js
@@ -18,7 +18,7 @@ test("Removed constructor with data throws an exception", function(assert) {
     var file = JSZipTestUtils.createZipAll().file("Hello.txt");
     assert.throws(
         function() {
-            new JSZip("");
+            var zip = new JSZip("");
         },
         /upgrade guide/,
         "new JSZip(data) throws an exception"

--- a/test/asserts/external.js
+++ b/test/asserts/external.js
@@ -21,6 +21,9 @@ function createPromiseProxy(OriginalPromise) {
     }
     MyShinyPromise.prototype.isACustomImplementation = true;
     for(var method in OriginalPromise) {
+        if (!OriginalPromise.hasOwnProperty(method)) {
+            continue;
+        }
         proxyMethod(method);
     }
     return MyShinyPromise;

--- a/test/asserts/external.js
+++ b/test/asserts/external.js
@@ -1,0 +1,75 @@
+/* jshint qunit: true */
+/* global JSZip,JSZipTestUtils */
+'use strict';
+
+QUnit.module("external");
+
+function createPromiseProxy(OriginalPromise) {
+    function MyShinyPromise () {
+        OriginalPromise.apply(this, arguments);
+        MyShinyPromise.calls++;
+    }
+    MyShinyPromise.calls = 0;
+    MyShinyPromise.prototype = OriginalPromise.prototype;
+    function proxyMethod(method) {
+        if (typeof OriginalPromise[method] === "function") {
+            MyShinyPromise[method] = function () {
+                MyShinyPromise.calls++;
+                return OriginalPromise[method].apply(OriginalPromise, arguments);
+            };
+        }
+    }
+    MyShinyPromise.prototype.isACustomImplementation = true;
+    for(var method in OriginalPromise) {
+        proxyMethod(method);
+    }
+    return MyShinyPromise;
+}
+
+test("external.Promise can be replaced in .async()", function (assert) {
+    var done = assert.async();
+    var OriginalPromise = JSZip.external.Promise;
+    var MyShinyPromise = createPromiseProxy(OriginalPromise);
+
+    JSZip.external.Promise = MyShinyPromise;
+
+    var promise = JSZipTestUtils.createZipAll().file("Hello.txt").async("string").then(function (result) {
+        ok(MyShinyPromise.calls > 0, "at least 1 call of the new Promise");
+        JSZip.external.Promise = OriginalPromise;
+        done();
+    })['catch'](JSZipTestUtils.assertNoError);
+
+    assert.ok(promise.isACustomImplementation, "the custom implementation is used");
+});
+
+test("external.Promise can be replaced in .generateAsync()", function (assert) {
+    var done = assert.async();
+    var OriginalPromise = JSZip.external.Promise;
+    var MyShinyPromise = createPromiseProxy(OriginalPromise);
+
+    JSZip.external.Promise = MyShinyPromise;
+
+    var promise = JSZipTestUtils.createZipAll().generateAsync({type:"string"}).then(function (result) {
+        ok(MyShinyPromise.calls > 0, "at least 1 call of the new Promise");
+        JSZip.external.Promise = OriginalPromise;
+        done();
+    })['catch'](JSZipTestUtils.assertNoError);
+
+    assert.ok(promise.isACustomImplementation, "the custom implementation is used");
+});
+
+JSZipTestUtils.testZipFile("external.Promise can be replaced in .loadAsync()", "ref/all.zip", function (all) {
+    stop();
+    var OriginalPromise = JSZip.external.Promise;
+    var MyShinyPromise = createPromiseProxy(OriginalPromise);
+
+    JSZip.external.Promise = MyShinyPromise;
+
+    var promise = JSZip.loadAsync(all).then(function (result) {
+        ok(MyShinyPromise.calls > 0, "at least 1 call of the new Promise");
+        JSZip.external.Promise = OriginalPromise;
+        start();
+    })['catch'](JSZipTestUtils.assertNoError);
+
+    ok(promise.isACustomImplementation, "the custom implementation is used");
+});

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -93,6 +93,7 @@ QUnit.module("file", function () {
         _actualTestFileDataGetters.testGetter(opts, "string");
         _actualTestFileDataGetters.testGetter(opts, "text");
         _actualTestFileDataGetters.testGetter(opts, "base64");
+        _actualTestFileDataGetters.testGetter(opts, "array");
         _actualTestFileDataGetters.testGetter(opts, "binarystring");
         _actualTestFileDataGetters.testGetter(opts, "arraybuffer");
         _actualTestFileDataGetters.testGetter(opts, "uint8array");
@@ -113,6 +114,7 @@ QUnit.module("file", function () {
             _actualTestFileDataGetters.testGetter(reloaded, "string");
             _actualTestFileDataGetters.testGetter(reloaded, "text");
             _actualTestFileDataGetters.testGetter(reloaded, "base64");
+            _actualTestFileDataGetters.testGetter(reloaded, "array");
             _actualTestFileDataGetters.testGetter(reloaded, "binarystring");
             _actualTestFileDataGetters.testGetter(reloaded, "arraybuffer");
             _actualTestFileDataGetters.testGetter(reloaded, "uint8array");
@@ -156,6 +158,12 @@ QUnit.module("file", function () {
         assert_binarystring : function (opts, err, bin, testName) {
             equal(err, null, testName + "no error");
             equal(bin, opts.rawData, testName + "content ok");
+        },
+        assert_array : function (opts, err, array, testName) {
+            equal(err, null, testName + "no error");
+            ok(array instanceof Array, testName + "the result is a instance of Array");
+            var actual = JSZipTestUtils.toString(array);
+            equal(actual, opts.rawData, testName + "content ok");
         },
         assert_arraybuffer : function (opts, err, buffer, testName) {
             if (JSZip.support.arraybuffer) {
@@ -252,6 +260,23 @@ QUnit.module("file", function () {
 
         zip = new JSZip();
         zip.file("file.txt", "test\r\ntest\r\n", {binary:true});
+        testFileDataGetters({name : "\\r\\n", zip : zip, textData : "test\r\ntest\r\n"});
+    });
+
+    test("add file: file(name, array)", function() {
+        var zip = new JSZip();
+        function toArray(str) {
+            var array = new Array(str.length);
+            for (var i = 0; i < str.length; i++) {
+                array[i] = str.charCodeAt(i);
+            }
+            return array;
+        }
+        zip.file("file.txt", toArray("\xE2\x82\xAC15\n"), {binary:true});
+        testFileDataGetters({name : "utf8", zip : zip, textData : "€15\n", rawData : "\xE2\x82\xAC15\n"});
+
+        zip = new JSZip();
+        zip.file("file.txt", toArray("test\r\ntest\r\n"), {binary:true});
         testFileDataGetters({name : "\\r\\n", zip : zip, textData : "test\r\ntest\r\n"});
     });
 

--- a/test/asserts/filter.js
+++ b/test/asserts/filter.js
@@ -10,11 +10,11 @@ test("Filtering a zip", function() {
     zip.file("2.txt", "2\n");
     zip.file("3.log", "3\n");
     var result = zip.filter(function (relativeFilename, file){
-        return relativeFilename.indexOf(".txt") != -1;
+        return relativeFilename.indexOf(".txt") !== -1;
     });
     equal(result.length, 2, "filter has filtered");
-    ok(result[0].name.indexOf(".txt") != -1, "filter has filtered the good file");
-    ok(result[1].name.indexOf(".txt") != -1, "filter has filtered the good file");
+    ok(result[0].name.indexOf(".txt") !== -1, "filter has filtered the good file");
+    ok(result[1].name.indexOf(".txt") !== -1, "filter has filtered the good file");
 });
 
 test("Filtering a zip from a relative path", function() {
@@ -29,7 +29,7 @@ test("Filtering a zip from a relative path", function() {
     var count = 0;
     var result = zip.folder("foo").filter(function (relativeFilename, file) {
         count++;
-        return relativeFilename.indexOf("3") != -1;
+        return relativeFilename.indexOf("3") !== -1;
     });
     equal(count, 3, "the callback has been called the right number of times");
     equal(result.length, 1, "filter has filtered");
@@ -46,7 +46,7 @@ test("Filtering a zip : the full path is still accessible", function() {
     zip.file("3.log", "3\n");
 
     var result = zip.folder("foo").filter(function (relativeFilename, file) {
-        return file.name.indexOf("3") != -1;
+        return file.name.indexOf("3") !== -1;
     });
     equal(result.length, 1, "the filter only match files/folders in the current folder");
     equal(result[0].name, "foo/3.log", "filter has filtered the good file");

--- a/test/asserts/generate.js
+++ b/test/asserts/generate.js
@@ -344,3 +344,24 @@ test("generateAsync keep the explicit / folder", function (assert) {
         done();
     })['catch'](JSZipTestUtils.assertNoError);
 });
+
+JSZipTestUtils.testZipFile("generate with promises as files", "ref/all.zip", function (expected) {
+    stop();
+    var zip = new JSZip();
+    zip.file("Hello.txt", new JSZip.external.Promise(function (resolve, reject) {
+        setTimeout(function () {
+            resolve("Hello World\n");
+        }, 50);
+    }));
+    zip.folder("images").file("smile.gif", new JSZip.external.Promise(function (resolve, reject) {
+        setTimeout(function () {
+            resolve("R0lGODdhBQAFAIACAAAAAP/eACwAAAAABQAFAAACCIwPkWerClIBADs=");
+        }, 100);
+    }), {base64: true});
+
+    zip.generateAsync({type:"string"})
+    .then(function (result) {
+        ok(JSZipTestUtils.similar(result, expected, 3 * JSZipTestUtils.MAX_BYTES_DIFFERENCE_PER_ZIP_ENTRY) , "generated ZIP matches reference ZIP");
+        start();
+    })['catch'](JSZipTestUtils.assertNoError);
+});

--- a/test/asserts/stream.js
+++ b/test/asserts/stream.js
@@ -255,6 +255,19 @@ QUnit.module("stream", function () {
             .resume();
         });
 
+        test("loadAsync ends with an error when called with a stream", function(assert) {
+            var done = assert.async();
+            var stream = JSZipTestUtils.createZipAll().generateNodeStream({"type":"nodebuffer"});
+            JSZip.loadAsync(stream).then(function () {
+                assert.ok(false, "loading a zip file from a stream is impossible");
+                done();
+            }, function (e) {
+                assert.ok(e.message.match("can't accept a stream when loading"), "the error message is useful");
+                done();
+            });
+
+        });
+
     } else {
         test("generateNodeStream generates an error", function(assert) {
             try {

--- a/test/helpers/node-test-utils.js
+++ b/test/helpers/node-test-utils.js
@@ -34,6 +34,9 @@ process.on('uncaughtException', function(err) {
     }
 
     for ( i in assertions ) {
+        if (!assertions.hasOwnProperty(i)) {
+            continue;
+        }
         QUnit[ i ] = applyCurrent( assertions[ i ] );
         global[ i ] = QUnit[ i ];
     }

--- a/test/index.html
+++ b/test/index.html
@@ -72,6 +72,7 @@ if(!window.JSZipUtils) {
 <script type="text/javascript" src="asserts/constructor.js"></script>
 <script type="text/javascript" src="asserts/delete.js"></script>
 <script type="text/javascript" src="asserts/deprecated.js"></script>
+<script type="text/javascript" src="asserts/external.js"></script>
 <script type="text/javascript" src="asserts/file.js"></script>
 <script type="text/javascript" src="asserts/filter.js"></script>
 <script type="text/javascript" src="asserts/foreach.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>JSZip Testing</title>
-<link media="screen" href="//code.jquery.com/qunit/qunit-1.22.0.css" type="text/css" rel="stylesheet">
-<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.22.0.js"></script>
+<link media="screen" href="//code.jquery.com/qunit/qunit-1.23.0.css" type="text/css" rel="stylesheet">
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.23.0.js"></script>
 <script>
 // no CDN, fallback on the npm version
 if(!window.QUnit) {


### PR DESCRIPTION
This pull request adds several things:

On features,
- Blob and Promise support in `loadAsync()` and `file()`
- support and tests for `JSZip.external`
- support for `async("array")`

On 
- enforcing rules in JSHint
- some documentation fixes
- upgrade some dependencies
- improve an error message

This should cover the remaining bullet points of #224.