### PR TITLE
Sync methods

### DIFF
--- a/lib/external.js
+++ b/lib/external.js
@@ -1,10 +1,12 @@
 'use strict';
 
 var ES6Promise = require("es6-promise").Promise;
+var delay = require("./utils").delay;
 
 /**
  * Let the user use/change some implementations.
  */
 module.exports = {
-    Promise: ES6Promise
+    Promise: ES6Promise,
+    delay: delay
 };

--- a/lib/load.js
+++ b/lib/load.js
@@ -2,7 +2,6 @@
 var utils = require('./utils');
 var external = require("./external");
 var utf8 = require('./utf8');
-var utils = require('./utils');
 var ZipEntries = require('./zipEntries');
 var Crc32Probe = require('./stream/Crc32Probe');
 var nodejsUtils = require("./nodejsUtils");

--- a/lib/object.js
+++ b/lib/object.js
@@ -7,9 +7,10 @@ var defaults = require('./defaults');
 var CompressedObject = require('./compressedObject');
 var ZipObject = require('./zipObject');
 var generate = require("./generate");
+var external = require("./external");
 var nodejsUtils = require("./nodejsUtils");
 var NodejsStreamInputAdapter = require("./nodejs/NodejsStreamInputAdapter");
-
+var SyncPromise = require('./promise/SyncPromise').SyncPromise;
 
 /**
  * Add a file in the current folder.
@@ -161,6 +162,24 @@ function isRegExp(object) {
 
 // return the actual prototype of JSZip
 var out = {
+
+    sync: function(cb) {
+        var saved_promise = external.Promise;
+        var saved_delay = external.delay;
+        try {
+            // convert async stuff to sync stuff
+            external.Promise = SyncPromise;
+            external.delay = function(callback, args, self) {
+                callback.apply(self || null, args || []);
+            };
+            // execute
+            return cb.call();
+        } finally {
+            external.delay = saved_delay;
+            external.Promise = saved_promise;
+        };
+
+    },
     /**
      * @see loadAsync
      */

--- a/lib/promise/SyncPromise.js
+++ b/lib/promise/SyncPromise.js
@@ -1,0 +1,137 @@
+
+/* a set synchronous promises to use with jszip */
+
+function PromiseBase() {
+    this._result = null;
+    this._error = null;
+    this._state = "PENDING";
+    return this;
+};
+
+PromiseBase.prototype.result = function() {
+    return this._result;
+};
+
+PromiseBase.prototype.error = function() {
+    return this._error;
+};
+
+PromiseBase.prototype.then = function(fulfilled, rejected) {
+    return new ThenPromise(this, fulfilled, rejected);
+};
+
+function SyncPromise(resolver) {
+    PromiseBase.call(this);
+    this._resolver = resolver;
+    this.run();
+    return this;
+}
+
+SyncPromise.prototype = Object.create(PromiseBase.prototype);
+SyncPromise.prototype.constructor = SyncPromise;
+
+SyncPromise.prototype.run = function() {
+    try {
+        var self = this;
+        this._resolver(
+            function (result) {
+                self._result = result;
+                self._state = "FULFILLED";
+            },
+            function (error) {
+                self._error = error;
+                self._state = "REJECTED";
+            });
+    } catch (e) {
+        this._error = e;
+        this._state = "REJECTED";
+        if(e instanceof Error)
+            throw e;
+        else
+            throw new Error(e);
+    }
+};
+
+function ThenPromise(promise, fulfilled, rejected) {
+    PromiseBase.call(this);
+    this._promise = promise;
+    this._fulfilled = fulfilled;
+    this._rejected = rejected;
+    this.run();
+    return this;
+};
+
+ThenPromise.prototype = Object.create(PromiseBase.prototype);
+ThenPromise.prototype.constructor = ThenPromise;
+
+ThenPromise.prototype.run = function() {
+    try {
+        this._result = this._promise.result();
+        this._error = this._promise.error();
+        if (this._error) {
+            if (this._rejected)
+                this._rejected(this._error);
+            this._state = "REJECTED";
+        } else {
+            this._result = this._fulfilled(this._result);
+            this._state = "FULFILLED";
+        }
+    } catch (e) {
+        this._error = e;
+        this._state = "REJECTED";
+        if(e instanceof Error)
+            throw e;
+        else
+            throw new Error(e);
+    }
+};
+
+function AllPromise(promises) {
+    PromiseBase.call(this);
+    this._promises = promises;
+    this.run();
+    return this;
+};
+
+AllPromise.prototype = Object.create(PromiseBase.prototype);
+AllPromise.prototype.constructor = AllPromise;
+
+
+AllPromise.prototype.run = function() {
+    try {
+        var results = [];
+        for(var i=0;i<this._promises.length;i++) {
+            var promise = this._promises[i];
+            var error = promise.error();
+            if(error) {
+                this._error = error;
+                this._state = "REJECTED";
+                return;
+            }
+            var result = promise.result();
+            results.push(result);
+        }
+        this._result = results;
+        this._state = "FULFILLED";
+    } catch (e) {
+        self._error = e;
+        self._state = "REJECTED";
+        if(e instanceof Error)
+            throw e;
+        else
+            throw new Error(e);
+    }
+};
+
+SyncPromise.resolve = function(value) {
+    var promise = new SyncPromise(function(resolve, reject) {
+        resolve(value);
+    });
+    return promise;
+};
+
+SyncPromise.all = function(promises) {
+    return new AllPromise(promises).result();
+};
+
+exports.SyncPromise = SyncPromise;

--- a/lib/stream/DataWorker.js
+++ b/lib/stream/DataWorker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utils');
+var external = require('../external');
 var GenericWorker = require('./GenericWorker');
 
 // the size of the generated chunks
@@ -56,7 +57,7 @@ DataWorker.prototype.resume = function () {
 
     if (!this._tickScheduled && this.dataIsReady) {
         this._tickScheduled = true;
-        utils.delay(this._tickAndRepeat, [], this);
+        external.delay(this._tickAndRepeat, [], this);
     }
     return true;
 };
@@ -71,7 +72,7 @@ DataWorker.prototype._tickAndRepeat = function() {
     }
     this._tick();
     if(!this.isFinished) {
-        utils.delay(this._tickAndRepeat, [], this);
+        external.delay(this._tickAndRepeat, [], this);
         this._tickScheduled = true;
     }
 };

--- a/lib/stream/StreamHelper.js
+++ b/lib/stream/StreamHelper.js
@@ -159,7 +159,7 @@ StreamHelper.prototype = {
             });
         } else {
             this._worker.on(evt, function () {
-                utils.delay(fn, arguments, self);
+                external.delay(fn, arguments, self);
             });
         }
         return this;
@@ -169,7 +169,7 @@ StreamHelper.prototype = {
      * @return {StreamHelper} the current helper.
      */
     resume : function () {
-        utils.delay(this._worker.resume, [], this._worker);
+        external.delay(this._worker.resume, [], this._worker);
         return this;
     },
     /**

--- a/test/asserts/syncpromise.js
+++ b/test/asserts/syncpromise.js
@@ -1,0 +1,39 @@
+/* jshint qunit: true */
+/* global JSZip,JSZipTestUtils */
+'use strict';
+var SyncPromise = require("../../../lib/promise/SyncPromise").SyncPromise;
+
+QUnit.module("SyncPromise");
+
+test("Fulfilling a promise", function(assert) {
+    var promise = new SyncPromise(function(resolve, reject){
+        resolve("ok");
+    });
+    assert.ok("ok"===promise.result());
+});
+
+test("Rejecting a promise", function(assert) {
+    var promise = new SyncPromise(function(resolve, reject){
+        reject("nok");
+    });
+    promise.get();
+    assert.ok("nok"===promise.error());
+});
+
+test("Throwing an error", function(assert) {
+    assert.throws(function() {
+        var promise = new SyncPromise(function(resolve, reject){
+            var a = b.c;
+        });
+        promise.result(); },
+        Error);
+});
+
+test("Thening a promise", function(assert) {
+    var promise = new SyncPromise(function(resolve, reject){
+        resolve("ok1");
+    }).then(function(value, reason){
+        return "ok2";
+    });
+    assert.ok("ok2"===promise.result());
+});


### PR DESCRIPTION
Fix proposal for #281.
The philosophy underlying this proposal is that any closure function that executes correctly in the future is bound to also execute correctly immediately.
This helps provide a straightforward proposal comprising:
 - a SyncPromise set of classes/functions, which expose the Promise contract elements actually used by JSZip, but execute them immediately instead of delaying them to the next tick
 - customization of the 'delay' function (enables immediate execution of a task instead of calling 'asap')
 - a simple 'sync' function on the JSZip object, which can be used to wrap any set of async JSZip calls.
The benefits of this approach are numerous:
 - it is now possible to zip/unzip (or any zip related activity) both synchronously and asynchronously
 - no change whatsoever is required in the core JSZip code (apart from calling external.delay instead of utils.delay)
 - JSZip users can easily debug their async code by temporarily wrapping it in a 'sync' call
Examples:
  ```
  function getZippedData(datas) {
    var zip = new JSZip();
    return zip.sync(function() {
        for (var key in datas)
            zip.file(key, datas[key]);
        var result = null;
        zip.generateAsync({type: "arraybuffer", compression: "DEFLATE"}).
            then(function(value) {
                result = value;
            });
        return result;
    });
}

function getUnzippedParts(zipped) {
    var zip = new JSZip();
    return zip.sync(function() {
        var parts = {};
        zip.loadAsync(zipped);
        zip.forEach(function (entry) {
            zip.file(entry)
                .async("arraybuffer")
                .then(function(value) {
                    parts[entry] = value;
                });
        });
        return parts;
    });
};
```