### PR TITLE
utils.delay: use macro tasks instead of micro tasks.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
       'saucelabs-qunit': {
           all: {
               options: {
-                  urls: ["http://127.0.0.1:9999/test/index.html"],
+                  urls: ["http://127.0.0.1:9999/test/index.html?hidepassed"],
                   build: process.env.TRAVIS_JOB_ID,
                   throttled: 3,
                   "max-duration" : 600, // seconds, IE6 is slow

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 var support = require('./support');
 var base64 = require('./base64');
 var nodejsUtils = require('./nodejsUtils');
-var asap = require('asap');
+var setImmediate = require('core-js/library/fn/set-immediate');
 var external = require("./external");
 
 
@@ -372,7 +372,7 @@ exports.pretty = function(str) {
  * @param {Array} args the arguments to give to the callback.
  */
 exports.delay = function(callback, args, self) {
-    asap(function () {
+    setImmediate(function () {
         callback.apply(self || null, args || []);
     });
 };

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
+    "core-js": "~2.3.0",
     "es6-promise": "~3.0.2",
     "pako": "~1.0.0",
-    "readable-stream": "~2.0.6",
-    "asap": "~2.0.3"
+    "readable-stream": "~2.0.6"
   },
   "license": "(MIT OR GPL-3.0)"
 }

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,8 @@ if(!window.QUnit) {
       var details = log[i];
       tests.push({
          name: details.name,
+         message: details.message,
+         module: details.module,
          result: details.result,
          expected: details.expected,
          actual: details.actual,


### PR DESCRIPTION
As says the documentation of [asap](https://github.com/kriskowal/asap),

> ASAP strives to schedule events to occur before yielding for IO,
> reflow, or redrawing.

The goal of async methods in JSZip is to not freeze the browser, a macro task
is a better choice here. See
https://github.com/YuzuJS/setImmediate#macrotasks-and-microtasks for a
description of micro/macro tasks.

Fix #280.