### PR TITLE
Add composer.json to maintain support at Packagist repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "stuk/jszip",
+  "type": "library",
+  "description": "Create, read and edit .zip files with Javascript",
+  "keywords": ["jszip", "create", "edit", "pdf"],
+  "homepage": "https://github.com/Stuk/jszip",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Stuart Knightley",
+      "email": "stuart@Stuartk.com",
+      "homepage": "http://stuartk.com/",
+      "role": "Developer"
+    },
+    {
+      "name": "Thiago Pereira Rosa",
+      "email": "thiagor@engineer.com",
+      "homepage": "http://coderi.com.br",
+      "role": "Contributor"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/Stuk/jszip/issues"
+  }
+}


### PR DESCRIPTION
Due to the importance and great use of this library, I believe that it should also be available in Packagist ([Composer] (https://getcomposer.org) dependencies manager) and not only in the [NPM](https://www.npmjs.com) as usual.

If accepted my Pull Request, I will send the configuration data to enable webhook to keep the library always updated with this original repository.

Thank you for the commitment to keep this active project.