### PR TITLE
Documentation: fix nodejs stream event.

### DIFF
--- a/documentation/api_jszip/generate_node_stream.md
+++ b/documentation/api_jszip/generate_node_stream.md
@@ -28,7 +28,9 @@ __Example__
 zip
 .generateNodeStream({streamFiles:true})
 .pipe(fs.createWriteStream('out.zip'))
-.on('end', function () {
+.on('finish', function () {
+    // JSZip generates a readable stream with a "end" event,
+    // but is piped here in a writable stream which emits a "finish" event.
     console.log("out.zip written.");
 });
 ```

--- a/documentation/api_zipobject/node_stream.md
+++ b/documentation/api_zipobject/node_stream.md
@@ -27,5 +27,9 @@ zip
 .file("my_text.txt")
 .nodeStream()
 .pipe(fs.createWriteStream('/tmp/my_text.txt'))
-.on("end", function () {...});
+.on('finish', function () {
+    // JSZip generates a readable stream with a "end" event,
+    // but is piped here in a writable stream which emits a "finish" event.
+    console.log("text file written.");
+});
 ```

--- a/documentation/howto/write_zip.md
+++ b/documentation/howto/write_zip.md
@@ -106,7 +106,9 @@ var zip = new JSZip();
 zip
 .generateNodeStream({type:'nodebuffer',streamFiles:true})
 .pipe(fs.createWriteStream('out.zip'))
-.on('end', function () {
+.on('finish', function () {
+    // JSZip generates a readable stream with a "end" event,
+    // but is piped here in a writable stream which emits a "finish" event.
     console.log("out.zip written.");
 });
 ```


### PR DESCRIPTION
The `end` event is for readable streams while `finish` is used for writable
streams. This commit updates the documentation to reflect that.

Fix #293