### PR TITLE
Add promises use to the upgrade guide.

### DIFF
--- a/LICENSE.markdown
+++ b/LICENSE.markdown
@@ -4,7 +4,7 @@ license.
 The MIT License
 ===============
 
-Copyright (c) 2009-2014 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso
+Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/documentation/api_jszip/file_name.md
+++ b/documentation/api_jszip/file_name.md
@@ -31,7 +31,8 @@ zip.file("file.txt").async("string") // a promise of "content"
 zip.file("file.txt").options.dir // false
 
 // utf8 example
-var zip = new JSZip(zipFromAjaxWithUTF8);
+var zip = new JSZip();
+zip.file("amount.txt", "€15");
 zip.file("amount.txt").async("string") // a promise of "€15"
 zip.file("amount.txt").async("arraybuffer") // a promise of an ArrayBuffer containing €15 encoded as utf8
 zip.file("amount.txt").async("uint8array") // a promise of an Uint8Array containing €15 encoded as utf8

--- a/documentation/api_jszip/load_async.md
+++ b/documentation/api_jszip/load_async.md
@@ -95,7 +95,7 @@ Using a custom charset :
 // using iconv-lite for example
 var iconv = require('iconv-lite');
 
-zip.load(content, {
+zip.loadAsync(content, {
     decodeFileName: function (bytes) {
         return iconv.decode(bytes, 'your-encoding');
     }

--- a/documentation/howto/read_zip.md
+++ b/documentation/howto/read_zip.md
@@ -19,12 +19,29 @@ documentation for more examples) :
 
 ```js
 JSZipUtils.getBinaryContent('path/to/content.zip', function(err, data) {
-  if(err) {
-    throw err; // or handle err
-  }
+    if(err) {
+        throw err; // or handle err
+    }
 
-  var zip = new JSZip(data);
+    JSZip.loadAsync(data).then(function () {
+        // ...
+    });
 });
+
+// or, with promises:
+
+new JSZip.external.Promise(function (resolve, reject) {
+    JSZipUtils.getBinaryContent('path/to/content.zip', function(err, data) {
+        if (err) {
+            reject(e);
+        } else {
+            resolve(data);
+        }
+    });
+}).then(function (data) {
+    return JSZip.loadAsync(data);
+})
+.then(...)
 ```
 
 <br>
@@ -63,16 +80,44 @@ var JSZip = require("jszip");
 
 // read a zip file
 fs.readFile("test.zip", function(err, data) {
-  if (err) throw err;
-  var zip = new JSZip(data);
+    if (err) throw err;
+    JSZip.loadAsync(data).then(function (zip) {
+        // ...
+    });
 });
+// or
+new JSZip.external.Promise(function (resolve, reject) {
+    fs.readFile("test.zip", function(err, data) {
+        if (err) {
+            reject(e);
+        } else {
+            resolve(data);
+        }
+    });
+}).then(function (data) {
+    return JSZip.loadAsync(data);
+})
+.then(...)
+
 
 // read a file and add it to a zip
 fs.readFile("picture.png", function(err, data) {
-  if (err) throw err;
-  var zip = new JSZip();
-  zip.file("picture.png", data);
+    if (err) throw err;
+    var zip = new JSZip();
+    zip.file("picture.png", data);
 });
+// or
+var contentPromise = new JSZip.external.Promise(function (resolve, reject) {
+    fs.readFile("picture.png", function(err, data) {
+        if (err) {
+            reject(e);
+        } else {
+            resolve(data);
+        }
+    });
+});
+zip.file("picture.png", contentPromise);
+
 
 // read a file as a stream and add it to a zip
 var stream = fs.createReadStream("picture.png");

--- a/documentation/limitations.md
+++ b/documentation/limitations.md
@@ -8,8 +8,8 @@ fullpage: true
 ### Not supported features
 
 All the features of zip files are not supported. Classic zip files will work
-but encrypted zip, multi-volume, etc are not supported and the load() method
-will throw an `Error`.
+but encrypted zip, multi-volume, etc are not supported and the loadAsync()
+method will return a failed promise.
 
 
 ### ZIP64 and 32bit integers

--- a/lib/license_header.js
+++ b/lib/license_header.js
@@ -3,7 +3,7 @@
 JSZip - A Javascript class for generating and reading zip files
 <http://stuartk.com/jszip>
 
-(c) 2009-2014 Stuart Knightley <stuart [at] stuartk.com>
+(c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>
 Dual licenced under the MIT license or GPLv3. See https://raw.github.com/Stuk/jszip/master/LICENSE.markdown.
 
 JSZip uses the library pako released under the MIT license :


### PR DESCRIPTION
`async` and `loadAsync` use promises but using them or chaining them is not
something obvious the first time. While this addition is not intended
as a full featured guide to promises, adding some examples will ease
the v2 -> v3 migration.

Also remove old methods from the documentation (the old constructor
with data and `load`).

Fix #297.