### PR TITLE
Harden base64 decode.

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -43,6 +43,18 @@ exports.decode = function(input) {
     var enc1, enc2, enc3, enc4;
     var i = 0, resultIndex = 0;
 
+    var dataUrlPrefix = "data:";
+
+    if (input.substr(dataUrlPrefix.length) === dataUrlPrefix) {
+        // This is a common error: people give a data url
+        // (data:image/png;base64,iVBOR...) with a {base64: true} and
+        // wonders why things don't work.
+        // We can detect that the string input looks like a data url but we
+        // *can't* be sure it is one: removing everything up to the comma would
+        // be too dangerous.
+        throw new Error("Invalid base64 input, it looks like a data url.");
+    }
+
     input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
 
     var totalLength = input.length * 3 / 4;
@@ -52,11 +64,20 @@ exports.decode = function(input) {
     if(input.charAt(input.length - 2) === _keyStr.charAt(64)) {
         totalLength--;
     }
+    if (totalLength % 1 !== 0) {
+        // totalLength is not an integer, the length does not match a valid
+        // base64 content. That can happen if:
+        // - the input is not a base64 content
+        // - the input is *almost* a base64 content, with a extra chars at the
+        //   beginning or at the end
+        // - the input uses a base64 variant (base64url for example)
+        throw new Error("Invalid base64 input, bad content length.");
+    }
     var output;
     if (support.uint8array) {
-        output = new Uint8Array(totalLength);
+        output = new Uint8Array(totalLength|0);
     } else {
-        output = new Array(totalLength);
+        output = new Array(totalLength|0);
     }
 
     while (i < input.length) {

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -86,6 +86,32 @@ QUnit.module("file", function () {
         })['catch'](JSZipTestUtils.assertNoError);
     });
 
+    test("add file: wrong string as base64", function(assert) {
+        var zip = new JSZip();
+        zip.file("text.txt", "a random string", {base64:true});
+        stop();
+        zip.generateAsync({type:"binarystring"}).then(function(actual) {
+            assert.ok(false, "generateAsync should fail");
+            start();
+        })['catch'](function (e) {
+            assert.ok(e.message, "Invalid base64 input, bad content length.", "triggers the correct error");
+            start();
+        });
+    });
+
+    test("add file: data url instead of base64", function(assert) {
+        var zip = new JSZip();
+        zip.file("text.txt", "data:image/png;base64,YmFzZTY0", {base64:true});
+        stop();
+        zip.generateAsync({type:"binarystring"}).then(function(actual) {
+            assert.ok(false, "generateAsync should fail");
+            start();
+        })['catch'](function (e) {
+            assert.ok(e.message, "Invalid base64 input, it looks like a data url.", "triggers the correct error");
+            start();
+        });
+    });
+
     function testFileDataGetters (opts) {
         if (typeof opts.rawData === "undefined") {
             opts.rawData = opts.textData;


### PR DESCRIPTION
A common mistake is to put a data url (from a canvas for example) as a base64
content. In that case, we got a float value as the computed length of the
result and creating an Uint8Array threw an error.

This commit hardens the base64 decode: if the computed length is not an
integer or if the content looks like a data url, a better error is
thrown (instead of "TypeError: invalid arguments").