### PR TITLE
Add JSZip.version and the version in the header.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,8 @@ module.exports = function(grunt) {
     tags.push(process.env.TRAVIS_BRANCH);
   }
 
+  var version = require("./package.json").version;
+
   grunt.initConfig({
       connect: {
           server: {
@@ -135,6 +137,7 @@ module.exports = function(grunt) {
         options: {
           browserifyOptions: {
             standalone: 'JSZip',
+            transform: ['package-json-versionify'],
             insertGlobalVars : {
               Buffer: function () {
                 // instead of the full polyfill, we just use the raw value
@@ -144,7 +147,7 @@ module.exports = function(grunt) {
             }
           },
           ignore : ["./lib/nodejs/*"],
-          banner : grunt.file.read('lib/license_header.js')
+          banner : grunt.file.read('lib/license_header.js').replace(/__VERSION__/, version)
         }
       }
     },
@@ -152,7 +155,7 @@ module.exports = function(grunt) {
       options: {
         mangle: true,
         preserveComments: false,
-        banner : grunt.file.read('lib/license_header.js')
+        banner : grunt.file.read('lib/license_header.js').replace(/__VERSION__/, version)
       },
       all: {
         src: 'dist/jszip.js',

--- a/documentation/_layouts/default.html
+++ b/documentation/_layouts/default.html
@@ -100,6 +100,7 @@
               <li><a href="{{site.baseurl}}/documentation/api_jszip/load_async_object.html">JSZip.loadAsync(data [, options])</a></li>
               <li><a href="{{site.baseurl}}/documentation/api_jszip/support.html">JSZip.support</a></li>
               <li><a href="{{site.baseurl}}/documentation/api_jszip/external.html">JSZip.external</a></li>
+              <li><a href="{{site.baseurl}}/documentation/api_jszip/version.html">JSZip.version</a></li>
             </ul>
           </li>
           <li><a href="{{site.baseurl}}/documentation/api_zipobject.html">ZipObject</a></li>

--- a/documentation/api_jszip/version.md
+++ b/documentation/api_jszip/version.md
@@ -1,0 +1,13 @@
+---
+title: "JSZip.version"
+layout: default
+section: api
+---
+
+The version of JSZip as a string.
+
+__Example__
+
+```js
+JSZip.version == "3.1.0";
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ JSZip.prototype = require('./object');
 JSZip.prototype.loadAsync = require('./load');
 JSZip.support = require('./support');
 JSZip.defaults = require('./defaults');
+JSZip.version = require('../package.json').version;
 
 JSZip.loadAsync = function (content, options) {
     return new JSZip().loadAsync(content, options);

--- a/lib/license_header.js
+++ b/lib/license_header.js
@@ -1,6 +1,6 @@
 /*!
 
-JSZip - A Javascript class for generating and reading zip files
+JSZip v__VERSION__ - A Javascript class for generating and reading zip files
 <http://stuartk.com/jszip>
 
 (c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "grunt-contrib-qunit": "~1.2.0",
     "grunt-contrib-uglify": "~1.0.0",
     "jszip-utils": "~0.0.2",
+    "package-json-versionify": "~1.0.2",
     "qunit-cli": "~0.2.0",
     "qunitjs": "~1.23.0",
     "tmp": "0.0.28"

--- a/test/asserts/version.js
+++ b/test/asserts/version.js
@@ -1,0 +1,10 @@
+/* jshint qunit: true */
+/* global JSZip,JSZipTestUtils */
+'use strict';
+
+QUnit.module("version");
+
+test("JSZip.version is correct", function(assert){
+    assert.ok(JSZip.version, "JSZip.version exists");
+    assert.ok(JSZip.version.match(/^\d+\.\d+\.\d+/), "JSZip.version looks like a correct version");
+});

--- a/test/index.html
+++ b/test/index.html
@@ -70,6 +70,7 @@ if(!window.JSZipUtils) {
 <script type="text/javascript" src="helpers/browser-test-utils.js"></script>
 
 <script type="text/javascript" src="asserts/constructor.js"></script>
+<script type="text/javascript" src="asserts/version.js"></script>
 <script type="text/javascript" src="asserts/delete.js"></script>
 <script type="text/javascript" src="asserts/deprecated.js"></script>
 <script type="text/javascript" src="asserts/external.js"></script>


### PR DESCRIPTION
This adds the version of JSZip in the header (to find it easily) but also
expose it in JSZip.version.

Fix #299.