### PR TITLE
Change JSZip.external.Promise implementation.

### DIFF
--- a/documentation/api_jszip/external.md
+++ b/documentation/api_jszip/external.md
@@ -4,11 +4,14 @@ layout: default
 section: api
 ---
 
-JSZip uses polyfills of objects that may not exist on every platform.
+JSZip uses objects that may not exist on every platform, in which case it uses
+a shim.
 Accessing or replacing these objects can sometimes be useful. JSZip.external
 contains the following properties :
 
 * `Promise` : the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) implementation used.
+
+The global object is prefered when available.
 
 __Example__
 

--- a/lib/external.js
+++ b/lib/external.js
@@ -3,7 +3,7 @@
 // load the global object first:
 // - it should be better integrated in the system (unhandledRejection in node)
 // - the environment may have a custom Promise implementation (see zone.js)
-var ES6Promise = global.Promise || require("vow").Promise;
+var ES6Promise = global.Promise || require("lie");
 
 /**
  * Let the user use/change some implementations.

--- a/lib/external.js
+++ b/lib/external.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var ES6Promise = require("es6-promise").Promise;
+// load the global object first:
+// - it should be better integrated in the system (unhandledRejection in node)
+// - the environment may have a custom Promise implementation (see zone.js)
+var ES6Promise = global.Promise || require("vow").Promise;
 
 /**
  * Let the user use/change some implementations.

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   "dependencies": {
     "core-js": "~2.3.0",
     "es6-promise": "~3.0.2",
+    "lie": "~3.1.0",
     "pako": "~1.0.2",
-    "readable-stream": "~2.0.6",
-    "vow": "~0.4.12"
+    "readable-stream": "~2.0.6"
   },
   "license": "(MIT OR GPL-3.0)"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "es6-promise": "~3.0.2",
     "pako": "~1.0.0",
     "readable-stream": "~2.0.6",
-    "asap": "~2.0.3"
+    "asap": "~2.0.3",
+    "vow": "~0.4.12"
   },
   "license": "(MIT OR GPL-3.0)"
 }

--- a/test/helpers/test-utils.js
+++ b/test/helpers/test-utils.js
@@ -203,5 +203,12 @@
         return base64Dict[input];
     };
 
+
+    if (global.JSZip) {
+        throw new Error("JSZip is already defined, we can't capture the global state *before* its load");
+    }
+
+    JSZipTestUtils.oldPromise = global.Promise;
+
     global.JSZipTestUtils = JSZipTestUtils;
 })(typeof window !== "undefined" && window || global);

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,9 @@ if(!window.QUnit) {
 }
 </script>
 
+<script type="text/javascript" src="helpers/test-utils.js"></script>
+<script type="text/javascript" src="helpers/browser-test-utils.js"></script>
+
 <script type="text/javascript" src="../dist/jszip.js"></script>
 
 <script type="text/javascript">
@@ -65,9 +68,6 @@ if(!window.JSZipUtils) {
    document.write('<!--[if IE]><script type="text/javascript" src="../node_modules/jszip-utils/dist/jszip-utils-ie.js"><\/script><![endif]-->');
 }
 </script>
-
-<script type="text/javascript" src="helpers/test-utils.js"></script>
-<script type="text/javascript" src="helpers/browser-test-utils.js"></script>
 
 <script type="text/javascript" src="asserts/constructor.js"></script>
 <script type="text/javascript" src="asserts/delete.js"></script>


### PR DESCRIPTION
Importing `es6-promise` had a side effect: this library replaces the
global Promise object (#304) (or tries to, #309). This is an intended
side effect from this library and while its version 4 should give us a
switch for this behavior, I don't know when it will be out (the master
branch of this project still auto replace the Promise).

I replaced it by `vow` which match the requirements:
- a Promise implementation
- a lightweight one
- works in IE6
- doesn't have too many dependencies

If a global Promise already exists, prefer it: a native promise is
likely to be better integrated anyway (unhandledRejection in node) and
some libraries (zone.js for example) replace global objects (#303).

I think it is enough for a semver minor version.

Fix #303 #304 #309