### PR TITLE
Update pako dependency version to 1.0.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "core-js": "~2.3.0",
     "es6-promise": "~3.0.2",
-    "pako": "~1.0.0",
+    "pako": "~1.0.2",
     "readable-stream": "~2.0.6"
   },
   "license": "(MIT OR GPL-3.0)"


### PR DESCRIPTION
While not strictly necessary (the `~1.0.0` includes it), I prefer an explicit
commit for this change.

Related to #320, fix a bug in deflate.