### PR TITLE
Use a hard-coded JSZip.version.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,10 @@ JSZip.prototype = require('./object');
 JSZip.prototype.loadAsync = require('./load');
 JSZip.support = require('./support');
 JSZip.defaults = require('./defaults');
-JSZip.version = require('../package.json').version;
+
+// TODO find a better way to handle this version,
+// a require('package.json').version doesn't work with webpack, see #327
+JSZip.version = "3.1.0";
 
 JSZip.loadAsync = function (content, options) {
     return new JSZip().loadAsync(content, options);


### PR DESCRIPTION
Webpack doesn't support requiring json files (like we did for
`JSZip.version`) without extra configuration. It breaks builds so this commit
fixes it by using an hard-coded string instead (we'll try to find a better way
later).

Fixes #327.