### PR TITLE
Fixed browserify support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,7 +146,6 @@ module.exports = function(grunt) {
               }
             }
           },
-          ignore : ["./lib/nodejs/*"],
           banner : grunt.file.read('lib/license_header.js').replace(/__VERSION__/, version)
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     }
   ],
   "main": "./lib/index",
+  "browser": {
+    "./lib/nodejs/NodejsStreamInputAdapter.js": false,
+    "./lib/nodejs/NodejsStreamOutputAdapter.js": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Stuk/jszip.git"


### PR DESCRIPTION
This fix allows transparent use of `require('jszip')` in browserified sources.