### PR TITLE
Small typo fixed

### DIFF
--- a/documentation/howto/read_zip.md
+++ b/documentation/howto/read_zip.md
@@ -33,7 +33,7 @@ JSZipUtils.getBinaryContent('path/to/content.zip', function(err, data) {
 new JSZip.external.Promise(function (resolve, reject) {
     JSZipUtils.getBinaryContent('path/to/content.zip', function(err, data) {
         if (err) {
-            reject(e);
+            reject(err);
         } else {
             resolve(data);
         }


### PR DESCRIPTION
There was an undefined variable. `e` was used instead of `err`