### PR TITLE
Fixed getting platform option of process.platform

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -346,15 +346,15 @@ var out = {
 
           // accept nodejs `process.platform`
           if(
-              options.platform === 'darwin' ||
-              options.platform === 'freebsd' ||
-              options.platform === 'linux' ||
-              options.platform === 'sunos'
+              opts.platform === 'darwin' ||
+              opts.platform === 'freebsd' ||
+              opts.platform === 'linux' ||
+              opts.platform === 'sunos'
           ) {
-              options.platform = "UNIX";
+              opts.platform = "UNIX";
           }
-          if (options.platform === 'win32') {
-              options.platform = "DOS";
+          if (opts.platform === 'win32') {
+              opts.platform = "DOS";
           }
 
           var comment = opts.comment || this.comment || "";


### PR DESCRIPTION
The existing code was modifying the input ```options``` object instead of resulting ```opts``` one.
This is a Node.js related fix.