### PR TITLE
Honor the options.binary flag.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -16,10 +16,10 @@ var NodejsStreamInputAdapter = require("./nodejs/NodejsStreamInputAdapter");
  * @private
  * @param {string} name the name of the file
  * @param {String|ArrayBuffer|Uint8Array|Buffer} data the data of the file
- * @param {Object} o the options of the file
+ * @param {Object} originalOptions the options of the file
  * @return {Object} the new file.
  */
-var fileAdd = function(name, data, o) {
+var fileAdd = function(name, data, originalOptions) {
     // be sure sub folders exist
     var dataType = utils.getTypeOf(data),
         parent;
@@ -29,7 +29,7 @@ var fileAdd = function(name, data, o) {
      * Correct options.
      */
 
-    o = utils.extend(o || {}, defaults);
+    var o = utils.extend(originalOptions || {}, defaults);
     o.date = o.date || new Date();
     if (o.compression !== null) {
         o.compression = o.compression.toUpperCase();
@@ -56,7 +56,9 @@ var fileAdd = function(name, data, o) {
     }
 
     var isUnicodeString = dataType === "string" && o.binary === false && o.base64 === false;
-    o.binary = !isUnicodeString;
+    if (!originalOptions || typeof originalOptions.binary === "undefined") {
+        o.binary = !isUnicodeString;
+    }
 
 
     var isCompressedEmpty = (data instanceof CompressedObject) && data.uncompressedSize === 0;

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -434,7 +434,7 @@ QUnit.module("file", function () {
         });
     }
 
-    test("add file: file(name, polyfill Promise[string])", function() {
+    test("add file: file(name, polyfill Promise[string] as binary)", function() {
         var str2promise = function (str) {
             return new JSZip.external.Promise(function(resolve, reject) {
                 setTimeout(function () {
@@ -443,7 +443,36 @@ QUnit.module("file", function () {
             });
         };
         var zip = new JSZip();
-        zip.file("file.txt", str2promise("\xE2\x82\xAC15\n"));
+        zip.file("file.txt", str2promise("\xE2\x82\xAC15\n"), {binary: true});
+        testFileDataGetters({name : "utf8", zip : zip, textData : "€15\n", rawData : "\xE2\x82\xAC15\n"});
+    });
+
+    test("add file: file(name, polyfill Promise[string] force text)", function() {
+        var str2promise = function (str) {
+            return new JSZip.external.Promise(function(resolve, reject) {
+                setTimeout(function () {
+                    resolve(str);
+                }, 10);
+            });
+        };
+        var zip = new JSZip();
+        zip.file("file.txt", str2promise("€15\n"), {binary: false});
+        testFileDataGetters({name : "utf8", zip : zip, textData : "€15\n", rawData : "\xE2\x82\xAC15\n"});
+    });
+
+    /*
+     * Fix #325 for this one
+     *
+    test("add file: file(name, polyfill Promise[string] as text)", function() {
+        var str2promise = function (str) {
+            return new JSZip.external.Promise(function(resolve, reject) {
+                setTimeout(function () {
+                    resolve(str);
+                }, 10);
+            });
+        };
+        var zip = new JSZip();
+        zip.file("file.txt", str2promise("€15\n"));
         testFileDataGetters({name : "utf8", zip : zip, textData : "€15\n", rawData : "\xE2\x82\xAC15\n"});
 
         zip = new JSZip();
@@ -454,6 +483,7 @@ QUnit.module("file", function () {
         zip.file("file.txt", str2promise(""));
         testFileDataGetters({name : "empty content", zip : zip, textData : ""});
     });
+   */
 
     if (JSZip.support.blob) {
         test("add file: file(name, polyfill Promise[Blob])", function() {


### PR DESCRIPTION
It mitigates #325: a promise of text can now be handled with
`{binary:false}`.