### PR TITLE
instanceof failing in window / iframe contexts

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -421,9 +421,10 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
     // if inputData is already a promise, this flatten it.
     var promise = external.Promise.resolve(inputData).then(function(data) {
         
-        var isBlob = data instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(data)) != -1;
         
-        if (support.blob && data instanceof Blob && typeof FileReader !== "undefined") {
+        var isBlob = data instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(data)) !== -1;
+
+        if (support.blob && isBlob && typeof FileReader !== "undefined") {
             return new external.Promise(function (resolve, reject) {
                 var reader = new FileReader();
 


### PR DESCRIPTION
`prepareContent` fails to properly derive type of data passed in, should the Blob originate from another context (window or iframe).

Described here from MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof)

> instanceof and multiple context (e.g. frames or windows)

> Different scope have different execution environments. This means that they have different built-ins (different global object, different constructors, etc.). This may result in unexpected results. For instance, [] instanceof window.frames[0].Array will return false, because Array.prototype !== window.frames[0].Array and arrays inherit from the former. This may not make sense at first but when you start dealing with multiple frames or windows in your script and pass objects from one context to another via functions, this will be a valid and strong issue. For instance, you can securely check if a given object is in fact an Array using Array.isArray(myObj)

Proposal is to first check `instanceof` (much faster), with a backup check against  `Object.prototype.toString` which is safe across contexts (http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/)

