### PR TITLE
Remove a copy with blob output.

### DIFF
--- a/lib/stream/StreamHelper.js
+++ b/lib/stream/StreamHelper.js
@@ -18,19 +18,24 @@ if (support.nodestream) {
  * Apply the final transformation of the data. If the user wants a Blob for
  * example, it's easier to work with an U8intArray and finally do the
  * ArrayBuffer/Blob conversion.
- * @param {String} type the name of the final type
+ * @param {String} resultType the name of the final type
+ * @param {String} chunkType the type of the data in the given array.
+ * @param {Array} dataArray the array containing the data chunks to concatenate
  * @param {String|Uint8Array|Buffer} content the content to transform
  * @param {String} mimeType the mime type of the content, if applicable.
  * @return {String|Uint8Array|ArrayBuffer|Buffer|Blob} the content in the right format.
  */
-function transformZipOutput(type, content, mimeType) {
-    switch(type) {
+function transformZipOutput(resultType, chunkType, dataArray, mimeType) {
+    var content = null;
+    switch(resultType) {
         case "blob" :
-            return utils.newBlob(utils.transformTo("arraybuffer", content), mimeType);
+            return utils.newBlob(dataArray, mimeType);
         case "base64" :
+            content = concat(chunkType, dataArray);
             return base64.encode(content);
         default :
-            return utils.transformTo(type, content);
+            content = concat(chunkType, dataArray);
+            return utils.transformTo(resultType, content);
     }
 }
 
@@ -93,7 +98,7 @@ function accumulate(helper, updateCallback) {
         })
         .on('end', function (){
             try {
-                var result = transformZipOutput(resultType, concat(chunkType, dataArray), mimeType);
+                var result = transformZipOutput(resultType, chunkType, dataArray, mimeType);
                 resolve(result);
             } catch (e) {
                 reject(e);
@@ -115,6 +120,8 @@ function StreamHelper(worker, outputType, mimeType) {
     var internalType = outputType;
     switch(outputType) {
         case "blob":
+            internalType = "arraybuffer";
+        break;
         case "arraybuffer":
             internalType = "uint8array";
         break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,18 +26,18 @@ function string2binary(str) {
 
 /**
  * Create a new blob with the given content and the given type.
- * @param {String|ArrayBuffer} part the content to put in the blob. DO NOT use
+ * @param {Array[String|ArrayBuffer]} parts the content to put in the blob. DO NOT use
  * an Uint8Array because the stock browser of android 4 won't accept it (it
  * will be silently converted to a string, "[object Uint8Array]").
  * @param {String} type the mime type of the blob.
  * @return {Blob} the created blob.
  */
-exports.newBlob = function(part, type) {
+exports.newBlob = function(parts, type) {
     exports.checkSupport("blob");
 
     try {
         // Blob constructor
-        return new Blob([part], {
+        return new Blob(parts, {
             type: type
         });
     }
@@ -47,7 +47,9 @@ exports.newBlob = function(part, type) {
             // deprecated, browser only, old way
             var Builder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder || window.MSBlobBuilder;
             var builder = new Builder();
-            builder.append(part);
+            for (var i = 0; i < parts.length; i++) {
+                builder.append(parts[i]);
+            }
             return builder.getBlob(type);
         }
         catch (e) {
@@ -266,7 +268,11 @@ transform["uint8array"] = {
         return arrayLikeToArrayLike(input, new Array(input.length));
     },
     "arraybuffer": function(input) {
-        return input.buffer;
+        // copy the uint8array: DO NOT propagate the original ArrayBuffer, it
+        // can be way larger (the whole zip file for example).
+        var copy = new Uint8Array(input.length);
+        copy.set(input, 0);
+        return copy.buffer;
     },
     "uint8array": identity,
     "nodebuffer": function(input) {


### PR DESCRIPTION
The actual memory consumption will actually depends on the
implementation but this fix could avoid a copy of the result.
To build the final Blob, instead of List[Uint8Array] -> ArrayBuffer -> Blob,
we can directly do List[ArrayBuffer] -> Blob.