### PR TITLE
Fix crc32 check for empty entries.

### DIFF
--- a/lib/stream/Crc32Probe.js
+++ b/lib/stream/Crc32Probe.js
@@ -10,6 +10,7 @@ var utils = require('../utils');
  */
 function Crc32Probe() {
     GenericWorker.call(this, "Crc32Probe");
+    this.withStreamInfo("crc32", 0);
 }
 utils.inherits(Crc32Probe, GenericWorker);
 

--- a/test/asserts/load.js
+++ b/test/asserts/load.js
@@ -473,6 +473,18 @@ QUnit.module("load", function () {
         });
     }
 
+    JSZipTestUtils.testZipFile("valid crc32", "ref/all.zip", function(file) {
+        stop();
+        JSZip.loadAsync(file, {checkCRC32:true})
+        .then(function success() {
+            start();
+            ok(true, "no exception were thrown");
+        }, function failure(e) {
+            start();
+            ok(false, "An exception were thrown: " + e.message);
+        });
+    });
+
     QUnit.module("not supported features");
 
     // zip -0 -X -e encrypted.zip Hello.txt


### PR DESCRIPTION
With entries with no content (folders for example) the crc32 attribute
wasn't initialized: `undefined === 0` was false, an error was triggered.