### PR TITLE
Fix the base64 error message with data uri.

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -45,7 +45,7 @@ exports.decode = function(input) {
 
     var dataUrlPrefix = "data:";
 
-    if (input.substr(dataUrlPrefix.length) === dataUrlPrefix) {
+    if (input.substr(0, dataUrlPrefix.length) === dataUrlPrefix) {
         // This is a common error: people give a data url
         // (data:image/png;base64,iVBOR...) with a {base64: true} and
         // wonders why things don't work.

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -109,7 +109,7 @@ QUnit.module("file", function () {
             assert.ok(false, "generateAsync should fail");
             start();
         })['catch'](function (e) {
-            assert.ok(e.message, "Invalid base64 input, bad content length.", "triggers the correct error");
+            assert.equal(e.message, "Invalid base64 input, bad content length.", "triggers the correct error");
             start();
         });
     });
@@ -122,7 +122,7 @@ QUnit.module("file", function () {
             assert.ok(false, "generateAsync should fail");
             start();
         })['catch'](function (e) {
-            assert.ok(e.message, "Invalid base64 input, it looks like a data url.", "triggers the correct error");
+            assert.equal(e.message, "Invalid base64 input, it looks like a data url.", "triggers the correct error");
             start();
         });
     });


### PR DESCRIPTION
A special message is displayed when we find a data uri instead of a real
base64 string. The check was false, the test checking it was false.