### PR TITLE
Travis build: lint before building.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 sudo: false
 matrix:
   include:
+    - node_js: "stable"
+      env: COMMAND=lint
     - node_js: "0.10"
       env: COMMAND=test-node
     - node_js: "0.12"


### PR DESCRIPTION
The default task of `grunt` does lint before building but the travis
configuration directly went for `grunt build`. This commit adds the
lint task.