### PR TITLE
Fix test and test error reporting.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -428,9 +428,9 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
     var promise = external.Promise.resolve(inputData).then(function(data) {
         
         
-        var isBlob = data instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(data)) !== -1;
+        var isBlob = support.blob && (data instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(data)) !== -1);
 
-        if (support.blob && isBlob && typeof FileReader !== "undefined") {
+        if (isBlob && typeof FileReader !== "undefined") {
             return new external.Promise(function (resolve, reject) {
                 var reader = new FileReader();
 

--- a/test/helpers/node-test-utils.js
+++ b/test/helpers/node-test-utils.js
@@ -12,6 +12,12 @@ global.JSZipTestUtils.loadZipFile = function(name, callback) {
 };
 process.on('uncaughtException', function(err) {
       console.log('uncaughtException: ' + err, err.stack);
+      process.exit(1);
+});
+
+process.on('unhandledRejection', function(err) {
+      console.log('unhandledRejection: ' + err, err.stack);
+      process.exit(1);
 });
 
 


### PR DESCRIPTION
The pull request #350 introduced a bug but the automated tests didn't
catch it:

> ReferenceError: Blob is not defined
>     at /home/travis/build/Stuk/jszip/lib/utils.js:425:38
>     at Array.1 (/home/travis/build/Stuk/jszip/node_modules/lie/lib/index.js:88:21)
>     at nextTick (/home/travis/build/Stuk/jszip/node_modules/lie/node_modules/immediate/lib/index.js:61:18)
>     at process._tickCallback (node.js:458:13)
>
> The command "npm run $COMMAND" exited with 0.
>
> Done. Your build exited with 0.

This commit fixes:
- the bug: check if Blobs are supported before actually using them
- the build: if an uncaught error/rejection happens, exit with a non
  zero code.