### PR TITLE
Fix tests on Opera.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -271,7 +271,9 @@ transform["uint8array"] = {
         // copy the uint8array: DO NOT propagate the original ArrayBuffer, it
         // can be way larger (the whole zip file for example).
         var copy = new Uint8Array(input.length);
-        copy.set(input, 0);
+        if (input.length) {
+            copy.set(input, 0);
+        }
         return copy.buffer;
     },
     "uint8array": identity,


### PR DESCRIPTION
On Opera, using `Uint8Array#set` with an empty source leads to a
"Offset larger than array size" (see
https://saucelabs.com/beta/tests/3e431fc46cdb4d2b8af024fc56abcb0d).

The saucelabs tests are all green.