### PR TITLE
Fixing broken require: require('util') -> require('../utils')

### DIFF
--- a/lib/nodejs/NodejsStreamOutputAdapter.js
+++ b/lib/nodejs/NodejsStreamOutputAdapter.js
@@ -2,8 +2,8 @@
 
 var Readable = require('readable-stream').Readable;
 
-var util = require('util');
-util.inherits(NodejsStreamOutputAdapter, Readable);
+var utils = require('../utils');
+utils.inherits(NodejsStreamOutputAdapter, Readable);
 
 /**
 * A nodejs stream using a worker as source.


### PR DESCRIPTION
### Description
In the file `lib/nodejs/NodejsStreamOutputAdapter.js`, it trying to require `util`, but really wanted to pull in `../utils`. 

This likely fell through the cracks because the only place this file is required in the code, it's wrapped in a `try/catch` clause where the `catch` resolves to a no-op.

It's worth noting that this was causing my project to break when using webpack, as webpack tries to go in and follow all the require statements and bundle everything up, but it would hit this and break.