### PR TITLE
Fix ie11 memory leak

### DIFF
--- a/lib/stream/StreamHelper.js
+++ b/lib/stream/StreamHelper.js
@@ -18,24 +18,19 @@ if (support.nodestream) {
  * Apply the final transformation of the data. If the user wants a Blob for
  * example, it's easier to work with an U8intArray and finally do the
  * ArrayBuffer/Blob conversion.
- * @param {String} resultType the name of the final type
- * @param {String} chunkType the type of the data in the given array.
- * @param {Array} dataArray the array containing the data chunks to concatenate
+ * @param {String} type the name of the final type
  * @param {String|Uint8Array|Buffer} content the content to transform
  * @param {String} mimeType the mime type of the content, if applicable.
  * @return {String|Uint8Array|ArrayBuffer|Buffer|Blob} the content in the right format.
  */
-function transformZipOutput(resultType, chunkType, dataArray, mimeType) {
-    var content = null;
-    switch(resultType) {
+function transformZipOutput(type, content, mimeType) {
+    switch(type) {
         case "blob" :
-            return utils.newBlob(dataArray, mimeType);
+            return utils.newBlob(utils.transformTo("arraybuffer", content), mimeType);
         case "base64" :
-            content = concat(chunkType, dataArray);
             return base64.encode(content);
         default :
-            content = concat(chunkType, dataArray);
-            return utils.transformTo(resultType, content);
+            return utils.transformTo(type, content);
     }
 }
 
@@ -98,7 +93,7 @@ function accumulate(helper, updateCallback) {
         })
         .on('end', function (){
             try {
-                var result = transformZipOutput(resultType, chunkType, dataArray, mimeType);
+                var result = transformZipOutput(resultType, concat(chunkType, dataArray), mimeType);
                 resolve(result);
             } catch (e) {
                 reject(e);
@@ -120,8 +115,6 @@ function StreamHelper(worker, outputType, mimeType) {
     var internalType = outputType;
     switch(outputType) {
         case "blob":
-            internalType = "arraybuffer";
-        break;
         case "arraybuffer":
             internalType = "uint8array";
         break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 var support = require('./support');
 var base64 = require('./base64');
@@ -26,41 +26,23 @@ function string2binary(str) {
 
 /**
  * Create a new blob with the given content and the given type.
- * @param {Array[String|ArrayBuffer]} parts the content to put in the blob. DO NOT use
+ * @param {String|ArrayBuffer} part the content to put in the blob. DO NOT use
  * an Uint8Array because the stock browser of android 4 won't accept it (it
  * will be silently converted to a string, "[object Uint8Array]").
+ *
+ * Use only ONE part to build the blob to avoid a memory leak in IE11 / Edge:
+ * when a large amount of Array is used to create the Blob, the amount of
+ * memory consumed is nearly 100 times the original data amount.
+ *
  * @param {String} type the mime type of the blob.
  * @return {Blob} the created blob.
  */
-exports.newBlob = function(parts, type) {
+exports.newBlob = function(part, type) {
     exports.checkSupport("blob");
 
     try {
-        // Fixed a memory leak occurred in IE11
-        // Note:
-        //    When a large amount of Array is generated in the Blob,
-        //    the amount of memory nearly 100 times the original data amount is consumed.
-        //    Change it to create a Blob only once after join.
-        if (window.MSBlobBuilder) {
-            var concatenation = function(segments) {
-                var sumLength = 0;
-                for (var i = 0; i < segments.length; ++i) {
-                    sumLength += segments[i].byteLength;
-                }
-                var whole = new Uint8Array(sumLength);
-                var pos = 0;
-                for (var j = 0; j < segments.length; ++j) {
-                    whole.set(new Uint8Array(segments[j]), pos);
-                    pos += segments[j].byteLength;
-                }
-                return whole.buffer;
-            };
-            // array
-            parts = [concatenation(parts)];
-        }
- 
         // Blob constructor
-        return new Blob(parts, {
+        return new Blob([part], {
             type: type
         });
     }
@@ -70,9 +52,7 @@ exports.newBlob = function(parts, type) {
             // deprecated, browser only, old way
             var Builder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder || window.MSBlobBuilder;
             var builder = new Builder();
-            for (var i = 0; i < parts.length; i++) {
-                builder.append(parts[i]);
-            }
+            builder.append(part);
             return builder.getBlob(type);
         }
         catch (e) {
@@ -291,13 +271,7 @@ transform["uint8array"] = {
         return arrayLikeToArrayLike(input, new Array(input.length));
     },
     "arraybuffer": function(input) {
-        // copy the uint8array: DO NOT propagate the original ArrayBuffer, it
-        // can be way larger (the whole zip file for example).
-        var copy = new Uint8Array(input.length);
-        if (input.length) {
-            copy.set(input, 0);
-        }
-        return copy.buffer;
+        return input.buffer;
     },
     "uint8array": identity,
     "nodebuffer": function(input) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ exports.newBlob = function(parts, type) {
         // Note:
         //    When a large amount of Array is generated in the Blob,
         //    the amount of memory nearly 100 times the original data amount is consumed.
-        //    Change it to create a BLOB only once after join.
+        //    Change it to create a Blob only once after join.
         if (window.MSBlobBuilder) {
             var concatenation = function(segments) {
                 var sumLength = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 var support = require('./support');
 var base64 = require('./base64');
@@ -36,6 +36,29 @@ exports.newBlob = function(parts, type) {
     exports.checkSupport("blob");
 
     try {
+        // Fixed a memory leak occurred in IE11
+        // Note:
+        //    When a large amount of Array is generated in the Blob,
+        //    the amount of memory nearly 100 times the original data amount is consumed.
+        //    Change it to create a BLOB only once after join.
+        if (window.MSBlobBuilder) {
+            var concatenation = function(segments) {
+                var sumLength = 0;
+                for (var i = 0; i < segments.length; ++i) {
+                    sumLength += segments[i].byteLength;
+                }
+                var whole = new Uint8Array(sumLength);
+                var pos = 0;
+                for (var j = 0; j < segments.length; ++j) {
+                    whole.set(new Uint8Array(segments[j]), pos);
+                    pos += segments[j].byteLength;
+                }
+                return whole.buffer;
+            };
+            // array
+            parts = [concatenation(parts)];
+        }
+ 
         // Blob constructor
         return new Blob(parts, {
             type: type


### PR DESCRIPTION
When IE 11 converts it to ZIP, it seems that it has not been released since it consumes a lot of memory.
This pull request implementing memory release.

- Test file total size is 12.6 MB
- Before: first, 92MB to 1.7GB,  and not release memory.
![before](https://cloud.githubusercontent.com/assets/1159599/26751924/7cd465fc-487f-11e7-9378-e3aab259baff.png)

- After:  fixed, There is no problem even if repeating.
![after](https://cloud.githubusercontent.com/assets/1159599/26751952/fd3a88c0-487f-11e7-8cf3-4ae6fcfdba63.png)

If necessary, I will show sample code as well.
