### PR TITLE
Handle 2 nodejs deprecations

### DIFF
--- a/lib/nodejsUtils.js
+++ b/lib/nodejsUtils.js
@@ -8,13 +8,31 @@ module.exports = {
      */
     isNode : typeof Buffer !== "undefined",
     /**
-     * Create a new nodejs Buffer.
+     * Create a new nodejs Buffer from an existing content.
      * @param {Object} data the data to pass to the constructor.
      * @param {String} encoding the encoding to use.
      * @return {Buffer} a new Buffer.
      */
-    newBuffer : function(data, encoding){
+    newBufferFrom: function(data, encoding) {
+        // XXX We can't use `Buffer.from` which comes from `Uint8Array.from`
+        // in nodejs v4 (< v.4.5). It's not the expected implementation (and
+        // has a different signature).
+        // see https://github.com/nodejs/node/issues/8053
+        // A condition on nodejs' version won't solve the issue as we don't
+        // control the Buffer polyfills that may or may not be used.
         return new Buffer(data, encoding);
+    },
+    /**
+     * Create a new nodejs Buffer with the specified size.
+     * @param {Integer} size the size of the buffer.
+     * @return {Buffer} a new Buffer.
+     */
+    allocBuffer: function (size) {
+        if (Buffer.alloc) {
+            return Buffer.alloc(size);
+        } else {
+            return new Buffer(size);
+        }
     },
     /**
      * Find out if an object is a Buffer.

--- a/lib/utf8.js
+++ b/lib/utf8.js
@@ -168,7 +168,7 @@ var buf2string = function (buf) {
  */
 exports.utf8encode = function utf8encode(str) {
     if (support.nodebuffer) {
-        return nodejsUtils.newBuffer(str, "utf-8");
+        return nodejsUtils.newBufferFrom(str, "utf-8");
     }
 
     return string2buf(str);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,7 +145,7 @@ var arrayToStringHelper = {
          */
         nodebuffer : (function () {
             try {
-                return support.nodebuffer && String.fromCharCode.apply(null, nodejsUtils.newBuffer(1)).length === 1;
+                return support.nodebuffer && String.fromCharCode.apply(null, nodejsUtils.allocBuffer(1)).length === 1;
             } catch (e) {
                 return false;
             }
@@ -225,7 +225,7 @@ transform["string"] = {
         return stringToArrayLike(input, new Uint8Array(input.length));
     },
     "nodebuffer": function(input) {
-        return stringToArrayLike(input, nodejsUtils.newBuffer(input.length));
+        return stringToArrayLike(input, nodejsUtils.allocBuffer(input.length));
     }
 };
 
@@ -240,7 +240,7 @@ transform["array"] = {
         return new Uint8Array(input);
     },
     "nodebuffer": function(input) {
-        return nodejsUtils.newBuffer(input);
+        return nodejsUtils.newBufferFrom(input);
     }
 };
 
@@ -257,7 +257,7 @@ transform["arraybuffer"] = {
         return new Uint8Array(input);
     },
     "nodebuffer": function(input) {
-        return nodejsUtils.newBuffer(new Uint8Array(input));
+        return nodejsUtils.newBufferFrom(new Uint8Array(input));
     }
 };
 
@@ -278,7 +278,7 @@ transform["uint8array"] = {
     },
     "uint8array": identity,
     "nodebuffer": function(input) {
-        return nodejsUtils.newBuffer(input);
+        return nodejsUtils.newBufferFrom(input);
     }
 };
 

--- a/test/asserts/stream.js
+++ b/test/asserts/stream.js
@@ -68,14 +68,22 @@ QUnit.module("stream", function () {
                 fs.readFile(tempFile, function (e, data) {
                     var actual = JSZipTestUtils.toString(data);
                     ok(JSZipTestUtils.similar(actual, expected, 3 * JSZipTestUtils.MAX_BYTES_DIFFERENCE_PER_ZIP_ENTRY) , "generated ZIP matches reference ZIP");
-                    start();
-                    fs.unlink(tempFile);
+                    fs.unlink(tempFile, function (err) {
+                        if (err) {
+                            ok(false, err);
+                        }
+                        start();
+                    });
                 });
             })
             .on("error", function (e) {
                 ok(false, e.message);
-                start();
-                fs.unlink(tempFile);
+                fs.unlink(tempFile, function (err) {
+                    if (err) {
+                        ok(false, err);
+                    }
+                    start();
+                });
             });
         });
     }
@@ -88,14 +96,22 @@ QUnit.module("stream", function () {
                 fs.readFile(tempFile, function (e, data) {
                     var actual = JSZipTestUtils.toString(data);
                     equal(actual, "Hello World\n", "the generated content is ok");
-                    done();
-                    fs.unlink(tempFile);
+                    fs.unlink(tempFile, function (err) {
+                        if (err) {
+                            assert.ok(false, err);
+                        }
+                        done();
+                    });
                 });
             })
             .on("error", function (e) {
                 ok(false, e.message);
-                done();
-                fs.unlink(tempFile);
+                fs.unlink(tempFile, function (err) {
+                    if (err) {
+                        assert.ok(false, err);
+                    }
+                    done();
+                });
             });
         });
     }


### PR DESCRIPTION
- [DEP0005] is a documentation-only deprecation about buffers
- [DEP0013] displayed warnings in the tests

  [DEP0005]: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
  [DEP0013]: https://nodejs.org/api/deprecations.html#deprecations_dep0013_fs_async_function_without_callback