### PR TITLE
Improve @std/esm compatibility

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -180,7 +180,7 @@ var out = {
     forEach: function(cb) {
         var filename, relativePath, file;
         for (filename in this.files) {
-            if (!this.files.hasOwnProperty(filename)) {
+            if (!Object.prototype.hasOwnProperty.call(this.files, filename)) {
                 continue;
             }
             file = this.files[filename];

--- a/lib/stream/GenericWorker.js
+++ b/lib/stream/GenericWorker.js
@@ -225,7 +225,7 @@ GenericWorker.prototype = {
      */
     mergeStreamInfo : function () {
         for(var key in this.extraStreamInfo) {
-            if (!this.extraStreamInfo.hasOwnProperty(key)) {
+            if (!Object.prototype.hasOwnProperty.call(this.extraStreamInfo, key)) {
                 continue;
             }
             this.streamInfo[key] = this.extraStreamInfo[key];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -407,7 +407,7 @@ exports.extend = function() {
     var result = {}, i, attr;
     for (i = 0; i < arguments.length; i++) { // arguments is not enumerable in some browsers
         for (attr in arguments[i]) {
-            if (arguments[i].hasOwnProperty(attr) && typeof result[attr] === "undefined") {
+            if (Object.prototype.hasOwnProperty.call(arguments[i], attr) && typeof result[attr] === "undefined") {
                 result[attr] = arguments[i][attr];
             }
         }

--- a/lib/zipEntry.js
+++ b/lib/zipEntry.js
@@ -17,7 +17,7 @@ var MADE_BY_UNIX = 0x03;
  */
 var findCompression = function(compressionMethod) {
     for (var method in compressions) {
-        if (!compressions.hasOwnProperty(method)) {
+        if (!Object.prototype.hasOwnProperty.call(compressions, method)) {
             continue;
         }
         if (compressions[method].magic === compressionMethod) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2799,9 +2799,9 @@
       }
     },
     "pako": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz",
-      "integrity": "sha1-0iBd/ludqK95fnwWPbTR+E5GALw="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parents": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "core-js": "~2.3.0",
     "es6-promise": "~3.0.2",
     "lie": "~3.1.0",
-    "pako": "~1.0.2",
+    "pako": "~1.0.6",
     "readable-stream": "~2.0.6"
   },
   "license": "(MIT OR GPL-3.0)"


### PR DESCRIPTION
Using esm triggered errors:

```js
require = require('@std/esm')(module, { cjs: true, esm: 'js' });
var JSZip = require("jszip");
var zip = new JSZip();
zip.file("test", "test") // TypeError: arguments[i].hasOwnProperty is not a function
```

Pako was just updated to fix this one too, we also include the fix.