### PR TITLE
Improve the error without type in async()

### DIFF
--- a/lib/zipObject.js
+++ b/lib/zipObject.js
@@ -37,20 +37,29 @@ ZipObject.prototype = {
      * @return StreamHelper the stream.
      */
     internalStream: function (type) {
-        var outputType = type.toLowerCase();
-        var askUnicodeString = outputType === "string" || outputType === "text";
-        if (outputType === "binarystring" || outputType === "text") {
-            outputType = "string";
-        }
-        var result = this._decompressWorker();
+        var result = null, outputType = "string";
+        try {
+            if (!type) {
+                throw new Error("No output type specified.");
+            }
+            outputType = type.toLowerCase();
+            var askUnicodeString = outputType === "string" || outputType === "text";
+            if (outputType === "binarystring" || outputType === "text") {
+                outputType = "string";
+            }
+            result = this._decompressWorker();
 
-        var isUnicodeString = !this._dataBinary;
+            var isUnicodeString = !this._dataBinary;
 
-        if (isUnicodeString && !askUnicodeString) {
-            result = result.pipe(new utf8.Utf8EncodeWorker());
-        }
-        if (!isUnicodeString && askUnicodeString) {
-            result = result.pipe(new utf8.Utf8DecodeWorker());
+            if (isUnicodeString && !askUnicodeString) {
+                result = result.pipe(new utf8.Utf8EncodeWorker());
+            }
+            if (!isUnicodeString && askUnicodeString) {
+                result = result.pipe(new utf8.Utf8DecodeWorker());
+            }
+        } catch (e) {
+            result = new GenericWorker("error");
+            result.error(e);
         }
 
         return new StreamHelper(result, outputType, "");

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -141,6 +141,7 @@ QUnit.module("file", function () {
         _actualTestFileDataGetters.testGetter(opts, "nodebuffer");
         _actualTestFileDataGetters.testGetter(opts, "blob");
         _actualTestFileDataGetters.testGetter(opts, "unknown");
+        _actualTestFileDataGetters.testGetter(opts, null);
 
         stop();
         opts.zip.generateAsync({type:"binarystring"})
@@ -162,6 +163,7 @@ QUnit.module("file", function () {
             _actualTestFileDataGetters.testGetter(reloaded, "nodebuffer");
             _actualTestFileDataGetters.testGetter(reloaded, "blob");
             _actualTestFileDataGetters.testGetter(reloaded, "unknown");
+            _actualTestFileDataGetters.testGetter(reloaded, null);
 
             opts.zip.file("file.txt", "changing the content after the call won't change the result");
             start();
@@ -253,6 +255,10 @@ QUnit.module("file", function () {
         assert_unknown : function (opts, err, buffer, testName) {
             equal(buffer, null, testName + "no data");
             ok(err.message.match("not supported by this platform"), testName + "the error message is useful");
+        },
+        assert_null : function (opts, err, buffer, testName) {
+            equal(buffer, null, testName + "no data");
+            ok(err.message.match("No output type specified"), testName + "the error message is useful");
         }
     };
 


### PR DESCRIPTION
Without any type given to `async()`, an error is thrown with a message
a bit useless. I re-used the check of `generateAsync()`: without type,
the result is promise failed with an error "No output type specified".

Fixes #479.