### PR TITLE
Fix Chrome trying to include the stream module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,7 @@ module.exports = function(grunt) {
             },
             builtins: false
           },
+          exclude: ["lib/readable-stream-browser.js"],
           banner : grunt.file.read('lib/license_header.js').replace(/__VERSION__/, version)
         }
       }


### PR DESCRIPTION
I have no idea what's going on in the issue 477, so I try removing the actual
line. This line isn't resolved to any lib (as the browserify build doesn't
include it) so we can safely remove it.