### PR TITLE
Fix deprecated Buffer constructor usage and add safeguards

### DIFF
--- a/lib/nodejsUtils.js
+++ b/lib/nodejsUtils.js
@@ -17,6 +17,11 @@ module.exports = {
         if (Buffer.from && Buffer.from !== Uint8Array.from) {
             return Buffer.from(data, encoding);
         } else {
+            if (typeof data === "number") {
+                // Safeguard for old Node.js versions. On newer versions,
+                // Buffer.from(number) / Buffer(number, encoding) already throw.
+                throw new Error("The \"data\" argument must not be a number");
+            }
             return new Buffer(data, encoding);
         }
     },
@@ -29,7 +34,9 @@ module.exports = {
         if (Buffer.alloc) {
             return Buffer.alloc(size);
         } else {
-            return new Buffer(size);
+            var buf = new Buffer(size);
+            buf.fill(0);
+            return buf;
         }
     },
     /**

--- a/lib/nodejsUtils.js
+++ b/lib/nodejsUtils.js
@@ -14,13 +14,11 @@ module.exports = {
      * @return {Buffer} a new Buffer.
      */
     newBufferFrom: function(data, encoding) {
-        // XXX We can't use `Buffer.from` which comes from `Uint8Array.from`
-        // in nodejs v4 (< v.4.5). It's not the expected implementation (and
-        // has a different signature).
-        // see https://github.com/nodejs/node/issues/8053
-        // A condition on nodejs' version won't solve the issue as we don't
-        // control the Buffer polyfills that may or may not be used.
-        return new Buffer(data, encoding);
+        if (Buffer.from && Buffer.from !== Uint8Array.from) {
+            return Buffer.from(data, encoding);
+        } else {
+            return new Buffer(data, encoding);
+        }
     },
     /**
      * Create a new nodejs Buffer with the specified size.


### PR DESCRIPTION
Two commits here, one for moving off the deprecated Buffer constructor API, and the second for the additional safeguards (just in case).

```
nodejsUtils: don't use deprecated Buffer api

This avoids using Buffer constructor API on newer Node.js versions.

To achieve that, Buffer.from presence is checked, with validating that it's
not the same method as Uint8Array.from.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
```

```
nodejsUtils: additional Buffer safeguards for older Node.js

1. In allocBuffer(), ensure buffers allocated with new Buffer() are zero-filled.
   On newer Node.js versions, Buffer.alloc() zero-fills already.

2. In newBufferFrom(), throw when 'data' argument is a number.
   On newer Node.js versions, Buffer.from(number)/new Buffer(number, encooding)
   throw already.
```