### PR TITLE
Use minified UMD bundle for unpkg, jsdelivr

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "browser": {
     "readable-stream": "./lib/readable-stream-browser.js"
   },
+  "unpkg": "./dist/jszip.min.js",
+  "jsdelivr": "./dist/jszip.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Stuk/jszip.git"


### PR DESCRIPTION
These popular CDNs will read the respective field from package.json when deciding which file to serve by default. Using the minified UMD bundle improves performance and removes the need to load direct dependencies.

There doesn't seem to be a consensus for a "cdn" field, so we have to linger on with these vendor-specific fields. See unpkg/unpkg.com#66