### PR TITLE
Add unpkg field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   ],
   "main": "./lib/index",
+  "unpkg": "./dist/jszip.js",
   "browser": {
     "readable-stream": "./lib/readable-stream-browser.js"
   },


### PR DESCRIPTION
This allows unpkg.com to point to the built version of JSZ|ip via https://unpkg.com/jszip. Currently, this points at lib/index (as it falls back to using the `main` field) which will not run in browsers.