### PR TITLE
dual-Licensing clearification

### DIFF
--- a/LICENSE.markdown
+++ b/LICENSE.markdown
@@ -1,4 +1,4 @@
-JSZip is dual licensed. You may use it under the MIT license *or* the GPLv3
+JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
 
 The MIT License


### PR DESCRIPTION
add "At your choice" to make clear, that the recipient of the software may choose one of the named licenses.