### PR TITLE
Feature/lazy blob reading

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -44,6 +44,15 @@ module.exports = function(data, options) {
     }
 
     return utils.prepareContent("the loaded zip file", data, true, options.optimizedBinaryString, options.base64)
+    .then(function(data){
+        return utils.getTypeOf(data) !== 'blob' ? data : new external.Promise(function (resolve){
+            var fr = new FileReader();
+            fr.onload = function(evt) {
+                resolve(evt.target.result)
+            }
+            fr.readAsArrayBuffer(data)
+        })
+    })
     .then(function(data) {
         var zipEntries = new ZipEntries(options);
         zipEntries.load(data);

--- a/lib/load.js
+++ b/lib/load.js
@@ -49,7 +49,7 @@ module.exports = function(data, options) {
             var fr = new FileReader();
             fr.onload = function(evt) {
                 resolve(evt.target.result);
-            }
+            };
             fr.readAsArrayBuffer(data);
         });
     })

--- a/lib/load.js
+++ b/lib/load.js
@@ -48,10 +48,10 @@ module.exports = function(data, options) {
         return utils.getTypeOf(data) !== 'blob' ? data : new external.Promise(function (resolve){
             var fr = new FileReader();
             fr.onload = function(evt) {
-                resolve(evt.target.result)
+                resolve(evt.target.result);
             }
-            fr.readAsArrayBuffer(data)
-        })
+            fr.readAsArrayBuffer(data);
+        });
     })
     .then(function(data) {
         var zipEntries = new ZipEntries(options);

--- a/lib/stream/DataWorker.js
+++ b/lib/stream/DataWorker.js
@@ -115,7 +115,6 @@ DataWorker.prototype._tick = function() {
                 };
                 reader.readAsArrayBuffer(chunk);
                 return;
-            break;
             case "string":
                 data = this.data.substring(this.index, nextIndex);
             break;

--- a/lib/stream/DataWorker.js
+++ b/lib/stream/DataWorker.js
@@ -28,7 +28,12 @@ function DataWorker(dataP) {
         self.data = data;
         self.max = data && data.length || 0;
         self.type = utils.getTypeOf(data);
-        if(!self.isPaused) {
+
+        if (self.type === 'blob') {
+            self.max = data.size;
+        }
+
+        if (!self.isPaused) {
             self._tickAndRepeat();
         }
     }, function (e) {
@@ -85,13 +90,32 @@ DataWorker.prototype._tick = function() {
         return false;
     }
 
+    var self = this;
     var size = DEFAULT_BLOCK_SIZE;
     var data = null, nextIndex = Math.min(this.max, this.index + size);
+
     if (this.index >= this.max) {
         // EOF
         return this.end();
     } else {
         switch(this.type) {
+            case "blob":
+                var chunk = self.data.slice(this.index, nextIndex);
+                var reader = new FileReader();
+                self.pause()
+                self.index = nextIndex;
+                reader.onload = function(e) {
+                    self.push({
+                        data : new Uint8Array(e.target.result),
+                        meta : {
+                            percent : self.max ? self.index / self.max * 100 : 0
+                        }
+                    });
+                    self.resume();
+                };
+                reader.readAsArrayBuffer(chunk);
+                return
+            break;
             case "string":
                 data = this.data.substring(this.index, nextIndex);
             break;

--- a/lib/stream/DataWorker.js
+++ b/lib/stream/DataWorker.js
@@ -102,7 +102,7 @@ DataWorker.prototype._tick = function() {
             case "blob":
                 var chunk = self.data.slice(this.index, nextIndex);
                 var reader = new FileReader();
-                self.pause()
+                self.pause();
                 self.index = nextIndex;
                 reader.onload = function(e) {
                     self.push({
@@ -114,7 +114,7 @@ DataWorker.prototype._tick = function() {
                     self.resume();
                 };
                 reader.readAsArrayBuffer(chunk);
-                return
+                return;
             break;
             case "string":
                 data = this.data.substring(this.index, nextIndex);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -427,7 +427,7 @@ exports.extend = function() {
  * @return {Promise} a promise in a format usable by JSZip.
  */
 exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinaryString, isBase64) {
-    return promise.then(function(data) {
+    return external.Promise.resolve(inputData).then(function(data) {
         var dataType = exports.getTypeOf(data);
 
         if (!dataType) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -324,8 +324,13 @@ exports.transformTo = function(outputType, input) {
  * @return {String} the (lowercase) type of the input.
  */
 exports.getTypeOf = function(input) {
+    var isBlob = support.blob && (input instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(input)) !== -1);
+
     if (typeof input === "string") {
         return "string";
+    }
+    if (isBlob) {
+        return "blob";
     }
     if (Object.prototype.toString.call(input) === "[object Array]") {
         return "array";
@@ -422,30 +427,6 @@ exports.extend = function() {
  * @return {Promise} a promise in a format usable by JSZip.
  */
 exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinaryString, isBase64) {
-
-    // if inputData is already a promise, this flatten it.
-    var promise = external.Promise.resolve(inputData).then(function(data) {
-        
-        
-        var isBlob = support.blob && (data instanceof Blob || ['[object File]', '[object Blob]'].indexOf(Object.prototype.toString.call(data)) !== -1);
-
-        if (isBlob && typeof FileReader !== "undefined") {
-            return new external.Promise(function (resolve, reject) {
-                var reader = new FileReader();
-
-                reader.onload = function(e) {
-                    resolve(e.target.result);
-                };
-                reader.onerror = function(e) {
-                    reject(e.target.error);
-                };
-                reader.readAsArrayBuffer(data);
-            });
-        } else {
-            return data;
-        }
-    });
-
     return promise.then(function(data) {
         var dataType = exports.getTypeOf(data);
 


### PR DESCRIPTION
Wow, work inside jszip was oldschool. Tried to implement an other feature and i notices that files where read as uint8array immediately all at once, that is really bad. I moved that part into the dataworker

would possible fix an issue like #343, #530

Really think you should consider dropping support for older platforms. Babel would have been something!

----

Anyhow what this PR dose is: 
it just passes blob/files along in prepareContent instead of reading all of it as a buffer all at once and then let DataWorker.js read the content one file at the time when it's needed