### PR TITLE
Port Node.js Buffer constructor to `Buffer.from`

### DIFF
--- a/lib/nodeBuffer.js
+++ b/lib/nodeBuffer.js
@@ -1,5 +1,9 @@
 'use strict';
 module.exports = function(data, encoding){
+    if (typeof data === 'number') {
+        return Buffer.alloc(data);
+    }
+
     return Buffer.from(data, encoding);
 };
 module.exports.test = function(b){

--- a/lib/nodeBuffer.js
+++ b/lib/nodeBuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function(data, encoding){
-    return new Buffer(data, encoding);
+    return Buffer.from(data, encoding);
 };
 module.exports.test = function(b){
     return Buffer.isBuffer(b);


### PR DESCRIPTION
The Buffer constructor is deprecated and emits a warning.

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/