### PR TITLE
Work around a jest/nodejs issue where instanceof ArrayBuffer fails 

### DIFF
--- a/lib/nodejsUtils.js
+++ b/lib/nodejsUtils.js
@@ -53,5 +53,14 @@ module.exports = {
             typeof obj.on === "function" &&
             typeof obj.pause === "function" &&
             typeof obj.resume === "function";
+    },
+
+    /* work around a jest/node issue where certain core classes are instantiated twice by the sandbox preventing instanceof from working */
+    isInstanceOf : function (obj, type) {
+        return obj instanceof type || ( function() {
+            var proto = Object.getPrototypeOf(obj || {});
+            return proto && proto.constructor && proto.constructor.name === type.name;
+        } () );
     }
+
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -327,16 +327,16 @@ exports.getTypeOf = function(input) {
     if (typeof input === "string") {
         return "string";
     }
-    if (Object.prototype.toString.call(input) === "[object Array]") {
+    if (Array.isArray(input)) {
         return "array";
     }
     if (support.nodebuffer && nodejsUtils.isBuffer(input)) {
         return "nodebuffer";
     }
-    if (support.uint8array && input instanceof Uint8Array) {
+    if (support.uint8array && nodejsUtils.isInstanceOf(input, Uint8Array)) {
         return "uint8array";
     }
-    if (support.arraybuffer && input instanceof ArrayBuffer) {
+    if (support.arraybuffer && nodejsUtils.isInstanceOf(input, ArrayBuffer)) {
         return "arraybuffer";
     }
 };


### PR DESCRIPTION
Work around a jest/nodejs issue where instanceof ArrayBuffer fails due to a nodes sandbox issue
See https://github.com/nodejs/node/issues/20978, marked as fixed, but seems to resurface with node 10.15.3 and jest 24.7.1