### PR TITLE
Minor fix in `Read a zip file`

### DIFF
--- a/documentation/examples.md
+++ b/documentation/examples.md
@@ -114,7 +114,7 @@ var new_zip = new JSZip();
 new_zip.loadAsync(content)
 .then(function(zip) {
     // you now have every files contained in the loaded zip
-    new_zip.file("hello.txt").async("string"); // a promise of "Hello World\n"
+    zip.file("hello.txt").async("string"); // a promise of "Hello World\n"
 });
 ```
 


### PR DESCRIPTION
the example has a minor typo: it uses the `new_zip` var (an instance of JSZip) to call new_zip.file('hello.txt').
The correct way is to call the function `file` on the obtained zip object.