### PR TITLE
Fix browser module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "main": "./lib/index",
   "browser": {
-    "readable-stream": "./lib/readable-stream-browser.js"
+    "readable-stream": "./lib/readable-stream-browser.js",
+    ".": "./dist/jszip.min.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When webpack/rollup or another bundler, implementing the
[`browser-resolve`](https://www.npmjs.com/package/browser-resolve)
spec tries to resolve `jszip` for a browser-based project they fail
with:

```
ERROR in ./node_modules/jszip/lib/readable-stream-browser.js
Module not found: Error: Can't resolve 'stream' in '/node_modules/jszip/lib'
```

Since you already produce a browser build, we just need to point to
it inside of `package.json`'s `browser` field.

PS: You'd probably want to double check the semantics of `"."`.

Looking at `browser-resolve` it seems that everything will work
as expected. Also, trying empirically with webpack, everything worked
out, but few more pairs of eyes would be greatly appreciated.

Also @sokra should be able to share a valuable opinion.

Fix #524
Fix #521
Fix #477