### PR TITLE
Default to NodeJS platform if available

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -326,7 +326,8 @@ var out = {
               compression: "STORE",
               compressionOptions : null,
               type: "",
-              platform: "DOS",
+              // default to NodeJS platform if available:
+              platform: (process && process.platform) || "DOS",
               comment: null,
               mimeType: 'application/zip',
               encodeFileName: utf8.utf8encode


### PR DESCRIPTION
Right now, `jszip` defaults to `"DOS"` for the zip file platform unless the user [overrides it](https://github.com/Stuk/jszip/blob/master/lib/object.js%23L350).  This change makes the default platform be that of NodeJS when on that runtime.