### PR TITLE
WIP: Treat a string wrapped in a Promise as non-binary

### DIFF
--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -442,6 +442,27 @@ QUnit.module("file", function () {
         });
     }
 
+    QUnit.test('add UTF-8 text without a Promise', async function (assert) {
+        var zip = new JSZip();
+        zip.file("file.html", "Hèllo");
+        const output = await zip.file("file.html").async("text");
+        assert.equal(output, "Hèllo");
+    });
+
+    QUnit.test('add UTF-8 text as a Promise with binary: false', async function (assert) {
+        var zip = new JSZip();
+        zip.file("file.html", Promise.resolve("Hèllo"), { binary: false });
+        const output = await zip.file("file.html").async("text");
+        assert.equal(output, "Hèllo");
+    });
+
+    QUnit.test('add UTF-8 text as a Promise without binary: false', async function (assert) {
+        var zip = new JSZip();
+        zip.file("file.html", Promise.resolve("Hèllo"));
+        const output = await zip.file("file.html").async("text");
+        assert.equal(output, "Hèllo");
+    });
+
     QUnit.test("add file: file(name, polyfill Promise[string] as binary)", function (assert) {
         var str2promise = function (str) {
             return new JSZip.external.Promise(function(resolve, reject) {


### PR DESCRIPTION
This adds a failing test that shows the problem described in https://github.com/Stuk/jszip/issues/325 and https://github.com/Stuk/jszip/issues/707