### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ matrix:
       env: COMMAND=test-node
     - node_js: "stable"
       env: COMMAND=test-browser
+    - node_js: "stable"
+      arch: ppc64le
+      env: COMMAND=lint
+    - node_js: "lts/*"
+      arch: ppc64le
+      env: COMMAND=test-node
+    - node_js: "stable"
+      arch: ppc64le
+      env: COMMAND=test-node
+    - node_js: "stable"
+      arch: ppc64le
+      env: COMMAND=test-browser
 env:
   global:
   - secure: MhA8GHU42X3GWTUMaqdZVvarx4BMjhQCUGNi3kvuD/iCmKVb7gMwj4jbds7AcJdsCRsRk8bBGzZs/E7HidBJMPDa5DhgLKy9EV1s42JlHq8lVzbJeWIGgrtyJvhVUkGRy2OJjnDSgh3U6elkQmvDn74jreSQc6m/yGoPFF1nqq8=


### PR DESCRIPTION
Adding power support for this package to support arch independent

I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.
