### PR TITLE
Removed duplicated require

### DIFF
--- a/lib/compressedObject.js
+++ b/lib/compressedObject.js
@@ -4,7 +4,6 @@ var external = require("./external");
 var DataWorker = require('./stream/DataWorker');
 var DataLengthProbe = require('./stream/DataLengthProbe');
 var Crc32Probe = require('./stream/Crc32Probe');
-var DataLengthProbe = require('./stream/DataLengthProbe');
 
 /**
  * Represent a compressed object, with everything needed to decompress it.

--- a/lib/load.js
+++ b/lib/load.js
@@ -2,7 +2,6 @@
 var utils = require('./utils');
 var external = require("./external");
 var utf8 = require('./utf8');
-var utils = require('./utils');
 var ZipEntries = require('./zipEntries');
 var Crc32Probe = require('./stream/Crc32Probe');
 var nodejsUtils = require("./nodejsUtils");


### PR DESCRIPTION
Hi,

`utils` is required twice here which makes rollup fail when processing the file:

```
[!] Error: Identifier 'utils' has already been declared
node_modules/jszip/lib/load.js (5:4)
3: var external = require("./external");
4: var utf8 = require('./utf8');
5: var utils = require('./utils');
```