### PR TITLE
Honor the local timezone, fix for #369, stop time travel!

### DIFF
--- a/lib/generate/ZipFileWorker.js
+++ b/lib/generate/ZipFileWorker.js
@@ -144,17 +144,17 @@ var generateZipParts = function(streamInfo, streamedContent, streamingEnded, off
     // @see http://www.delorie.com/djgpp/doc/rbinter/it/65/16.html
     // @see http://www.delorie.com/djgpp/doc/rbinter/it/66/16.html
 
-    dosTime = date.getUTCHours();
+    dosTime = date.getHours();
     dosTime = dosTime << 6;
-    dosTime = dosTime | date.getUTCMinutes();
+    dosTime = dosTime | date.getMinutes();
     dosTime = dosTime << 5;
-    dosTime = dosTime | date.getUTCSeconds() / 2;
+    dosTime = dosTime | date.getSeconds() / 2;
 
-    dosDate = date.getUTCFullYear() - 1980;
+    dosDate = date.getFullYear() - 1980;
     dosDate = dosDate << 4;
-    dosDate = dosDate | (date.getUTCMonth() + 1);
+    dosDate = dosDate | (date.getMonth() + 1);
     dosDate = dosDate << 5;
-    dosDate = dosDate | date.getUTCDate();
+    dosDate = dosDate | date.getDate();
 
     if (useUTF8ForFileName) {
         // set the unicode path extra field. unzip needs at least one extra

--- a/lib/reader/DataReader.js
+++ b/lib/reader/DataReader.js
@@ -104,13 +104,13 @@ DataReader.prototype = {
      */
     readDate: function() {
         var dostime = this.readInt(4);
-        return new Date(Date.UTC(
+        return new Date(
         ((dostime >> 25) & 0x7f) + 1980, // year
         ((dostime >> 21) & 0x0f) - 1, // month
         (dostime >> 16) & 0x1f, // day
         (dostime >> 11) & 0x1f, // hour
         (dostime >> 5) & 0x3f, // minute
-        (dostime & 0x1f) << 1)); // second
+        (dostime & 0x1f) << 1); // second
     }
 };
 module.exports = DataReader;

--- a/test/369utc.js
+++ b/test/369utc.js
@@ -1,0 +1,12 @@
+JSZip = require ("../dist/jszip");
+fs = require ("fs");
+
+var zip = new JSZip();
+
+zip.file("Hello.txt", "Hello World\n");
+
+zip.generateAsync({type: "nodebuffer",compression: "DEFLATE"}).then(function(content) {
+    // see FileSaver.js
+    fs.writeFileSync("example.zip",content);
+}).catch((e) =>console.log(e) );
+

--- a/test/369utc.sh
+++ b/test/369utc.sh
@@ -1,6 +1,5 @@
 
 #!/bin/sh -xe
-
 # test case for https://github.com/Stuk/jszip/issues/369
 
 rm -f example.zip Hello.txt
@@ -17,9 +16,11 @@ modseconds=`date --date="${moddatestring}" +"%s"`
 echo mod seconds $modseconds
 nowseconds=` date +"%s"`
 echo now  $nowseconds
-
 if [ $modseconds -gt $nowseconds ]; then
   echo error - time travel is not possible - file is from the future
+  exit -4
 fi
+echo pass
+exit 0;
 
 

--- a/test/369utc.sh
+++ b/test/369utc.sh
@@ -1,0 +1,25 @@
+
+#!/bin/sh -xe
+
+# test case for https://github.com/Stuk/jszip/issues/369
+
+rm -f example.zip Hello.txt
+export  TZ=PST5PDT
+node  369utc.js #creates exmaple.zip 
+unzip example.zip
+echo mod time 
+ls -l --full-time Hello.txt
+echo create time
+ls -cl --full-time Hello.txt
+moddatestring=`ls -l --full-time Hello.txt | awk '// {print $6, $7 , $8}' `
+echo $moddatestring
+modseconds=`date --date="${moddatestring}" +"%s"`
+echo mod seconds $modseconds
+nowseconds=` date +"%s"`
+echo now  $nowseconds
+
+if [ $modseconds -gt $nowseconds ]; then
+  echo error - time travel is not possible - file is from the future
+fi
+
+


### PR DESCRIPTION
Since there is no convention  for timezones in zips, it's incorrect to assume they are utc. This leads to astonishing behaviour where files are unpacked with different timestamps than they were packed with.  (and differs form the command line zip)
The change strips out the explicit UTC calls and relies on the environments'  locale. 
A test case is included that uses posix style TZ to demonstrate the bug and the fix. 