### PR TITLE
Support package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
     "readable-stream": "./lib/readable-stream-browser.js",
     ".": "./dist/jszip.min.js"
   },
+  "exports": {
+    ".": {
+      "node": "./lib/index.js",
+      "default": "./dist/jszip.js"
+    }
+  },
   "types": "./index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://nodejs.org/api/packages.html#packages_conditional_exports for how package exports work.

The ES import statement `import /* */ from "jszip"` would be resolved as:
- `./lib/index.js` if running in Node environment,
- `./dist/jszip.js` otherwise.