### PR TITLE
fix(browser): redirect main to dist on browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./lib/index",
   "browser": {
     "readable-stream": "./lib/readable-stream-browser.js",
-    ".": "./dist/jszip.min.js"
+    "./lib/index": "./dist/jszip.min.js"
   },
   "types": "./index.d.ts",
   "repository": {


### PR DESCRIPTION
Fixes #724

## Notes

#724 may be a bug with Webpack 5's `.` resolution. The standard isn't very well documented so it's hard to know expected behaviour.

However, I think it makes sense to redirect `./lib/index` rather than `.` as it's the `main` module. Browserify's [example](https://github.com/browserify/browserify#browser-field) uses this approach. This also fixes the Webpack 5 issue.