### PR TITLE
fix: tiny typo

### DIFF
--- a/documentation/examples.md
+++ b/documentation/examples.md
@@ -106,7 +106,7 @@ if (JSZip.support.uint8array) {
 
 With `.loadAsync(data)` you can load a zip file. Check
 [this page]({{site.baseurl}}/documentation/howto/read_zip.html) to see how to
-do properly (it's more tricky that it seems).
+do properly (it's more tricky than it seems).
 
 ```js
 var new_zip = new JSZip();


### PR DESCRIPTION
Changed `it's more tricky that it seems` to `it's more tricky than it seems` because I was supposed to. 😊