### PR TITLE
update license to be valid spdx identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "readable-stream": "~2.3.6",
     "set-immediate-shim": "~1.0.1"
   },
-  "license": "(MIT OR GPL-3.0)"
+  "license": "(MIT OR GPL-3.0-or-later)"
 }


### PR DESCRIPTION
`GPL-3.0` is deprecated and should be replaced with `GPL-3.0-or-later` (or `GPL-3.0-only`).