### PR TITLE
Fix 32-bit limitation when a file inside the zip is bigger than 2GB.

### DIFF
--- a/dist/jszip.js
+++ b/dist/jszip.js
@@ -1855,7 +1855,7 @@ DataReader.prototype = {
             i;
         this.checkOffset(size);
         for (i = this.index + size - 1; i >= this.index; i--) {
-            result = (result << 8) + this.byteAt(i);
+            result = (result * 256) + this.byteAt(i);
         }
         this.index += size;
         return result;

--- a/lib/reader/DataReader.js
+++ b/lib/reader/DataReader.js
@@ -61,7 +61,7 @@ DataReader.prototype = {
             i;
         this.checkOffset(size);
         for (i = this.index + size - 1; i >= this.index; i--) {
-            result = (result << 8) + this.byteAt(i);
+            result = (result * 256) + this.byteAt(i);
         }
         this.index += size;
         return result;


### PR DESCRIPTION
Fix 32-bit limitation showcased at
https://github.com/Stuk/jszip/issues/777
which causes
Bug : uncompressed data size mismatch
when a file inside the zip is bigger than 2GB.