### PR TITLE
Added example to transform FormData to zip

### DIFF
--- a/documentation/howto/formdata_to_zip.md
+++ b/documentation/howto/formdata_to_zip.md
@@ -17,8 +17,7 @@ $(form).on('submit', e => {
 
 To convert from the FormData to zip all of the files, you can parse it easily and add all of the files to the zip:
 
-```
-
+```js
 $('form#myform').on('submit', e => {
   e.preventDefault();
   const form = new FormData(e.target);


### PR DESCRIPTION
Added example to transform a FormData instance to zip, considering we want all of the file fields to be added to the zip