### PR TITLE
Add null type to currentFile in metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ interface JSZipSupport {
     nodebuffer: boolean;
 }
 
-type Compression = "STORE" | "DEFLATE";
+type Compression = 'STORE' | 'DEFLATE';
 
 /**
  * Depends on the compression type. With `STORE` (no compression), these options are ignored. With
@@ -23,7 +23,7 @@ interface CompressionOptions {
     level: number;
 }
 
-interface Metadata {
+interface Metadata  {
     percent: number;
     currentFile: string | null;
 }
@@ -64,9 +64,7 @@ interface OutputByType {
 //     compressedContent: string|ArrayBuffer|Uint8Array|Buffer;
 // }
 
-type InputFileFormat =
-    | InputByType[keyof InputByType]
-    | Promise<InputByType[keyof InputByType]>;
+type InputFileFormat = InputByType[keyof InputByType] | Promise<InputByType[keyof InputByType]>;
 
 declare namespace JSZip {
     type InputType = keyof InputByType;
@@ -95,14 +93,8 @@ declare namespace JSZip {
          * @param onUpdate a function to call on each internal update.
          * @return Promise the promise of the result.
          */
-        async<T extends OutputType>(
-            type: T,
-            onUpdate?: OnUpdateCallback
-        ): Promise<OutputByType[T]>;
-        nodeStream(
-            type?: "nodebuffer",
-            onUpdate?: OnUpdateCallback
-        ): NodeJS.ReadableStream;
+        async<T extends OutputType>(type: T, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
+        nodeStream(type?: 'nodebuffer', onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
     }
 
     interface JSZipFileOptions {
@@ -167,7 +159,7 @@ declare namespace JSZip {
         /** Stream the files and create file descriptors */
         streamFiles?: boolean;
         /** DOS (default) or UNIX */
-        platform?: "DOS" | "UNIX";
+        platform?: 'DOS' | 'UNIX';
     }
 
     interface JSZipLoadOptions {
@@ -183,17 +175,17 @@ declare namespace JSZip {
         currentFile: string;
     }
 
-    type DataEventCallback<T> = (dataChunk: T, metadata: JSZipMetadata) => void;
-    type EndEventCallback = () => void;
-    type ErrorEventCallback = (error: Error) => void;
+    type DataEventCallback<T> = (dataChunk: T, metadata: JSZipMetadata) => void
+    type EndEventCallback = () => void
+    type ErrorEventCallback = (error: Error) => void
 
     interface JSZipStreamHelper<T> {
         /**
          * Register a listener on an event
          */
-        on(event: "data", callback: DataEventCallback<T>): this;
-        on(event: "end", callback: EndEventCallback): this;
-        on(event: "error", callback: ErrorEventCallback): this;
+        on(event: 'data', callback: DataEventCallback<T>): this;
+        on(event: 'end', callback: EndEventCallback): this;
+        on(event: 'error', callback: ErrorEventCallback): this;
 
         /**
          * Read the whole stream and call a callback with the complete content
@@ -201,9 +193,7 @@ declare namespace JSZip {
          * @param updateCallback The function called every time the stream updates
          * @return A Promise of the full content
          */
-        accumulate(
-            updateCallback?: (metadata: JSZipMetadata) => void
-        ): Promise<T>;
+        accumulate(updateCallback?: (metadata: JSZipMetadata) => void): Promise<T>;
 
         /**
          * Resume the stream if the stream is paused. Once resumed, the stream starts sending data events again
@@ -222,7 +212,7 @@ declare namespace JSZip {
 }
 
 interface JSZip {
-    files: { [key: string]: JSZip.JSZipObject };
+    files: {[key: string]: JSZip.JSZipObject};
 
     /**
      * Get a file from the archive
@@ -248,16 +238,8 @@ interface JSZip {
      * @param options Optional information about the file
      * @return JSZip object
      */
-    file<T extends JSZip.InputType>(
-        path: string,
-        data: InputByType[T] | Promise<InputByType[T]>,
-        options?: JSZip.JSZipFileOptions
-    ): this;
-    file<T extends JSZip.InputType>(
-        path: string,
-        data: null,
-        options?: JSZip.JSZipFileOptions & { dir: true }
-    ): this;
+    file<T extends JSZip.InputType>(path: string, data: InputByType[T] | Promise<InputByType[T]>, options?: JSZip.JSZipFileOptions): this;
+    file<T extends JSZip.InputType>(path: string, data: null, options?: JSZip.JSZipFileOptions & { dir: true }): this;
 
     /**
      * Returns an new JSZip instance with the given folder as root
@@ -280,9 +262,7 @@ interface JSZip {
      *
      * @param callback function
      */
-    forEach(
-        callback: (relativePath: string, file: JSZip.JSZipObject) => void
-    ): void;
+    forEach(callback: (relativePath: string, file: JSZip.JSZipObject) => void): void;
 
     /**
      * Get all files which match the given filter function
@@ -290,9 +270,7 @@ interface JSZip {
      * @param predicate Filter function
      * @return Array of matched elements
      */
-    filter(
-        predicate: (relativePath: string, file: JSZip.JSZipObject) => boolean
-    ): JSZip.JSZipObject[];
+    filter(predicate: (relativePath: string, file: JSZip.JSZipObject) => boolean): JSZip.JSZipObject[];
 
     /**
      * Removes the file or folder from the archive
@@ -309,10 +287,7 @@ interface JSZip {
      * @param onUpdate The optional function called on each internal update with the metadata.
      * @return The serialized archive
      */
-    generateAsync<T extends JSZip.OutputType>(
-        options?: JSZip.JSZipGeneratorOptions<T>,
-        onUpdate?: OnUpdateCallback
-    ): Promise<OutputByType[T]>;
+    generateAsync<T extends JSZip.OutputType>(options?: JSZip.JSZipGeneratorOptions<T>, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
 
     /**
      * Generates a new archive asynchronously
@@ -321,10 +296,7 @@ interface JSZip {
      * @param onUpdate The optional function called on each internal update with the metadata.
      * @return A Node.js `ReadableStream`
      */
-    generateNodeStream(
-        options?: JSZip.JSZipGeneratorOptions<"nodebuffer">,
-        onUpdate?: OnUpdateCallback
-    ): NodeJS.ReadableStream;
+    generateNodeStream(options?: JSZip.JSZipGeneratorOptions<'nodebuffer'>, onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
 
     /**
      * Generates the complete zip file with the internal stream implementation
@@ -332,9 +304,7 @@ interface JSZip {
      * @param options Optional options for the generator
      * @return a StreamHelper
      */
-    generateInternalStream<T extends JSZip.OutputType>(
-        options?: JSZip.JSZipGeneratorOptions<T>
-    ): JSZip.JSZipStreamHelper<OutputByType[T]>;
+    generateInternalStream<T extends JSZip.OutputType>(options?: JSZip.JSZipGeneratorOptions<T>): JSZip.JSZipStreamHelper<OutputByType[T]>;
 
     /**
      * Deserialize zip file asynchronously
@@ -343,15 +313,12 @@ interface JSZip {
      * @param options Options for deserializing
      * @return Returns promise
      */
-    loadAsync(
-        data: InputFileFormat,
-        options?: JSZip.JSZipLoadOptions
-    ): Promise<JSZip>;
+    loadAsync(data: InputFileFormat, options?: JSZip.JSZipLoadOptions): Promise<JSZip>;
 
     /**
      * Create JSZip instance
      */
-    new (): this;
+    new(): this;
 
     (): JSZip;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ interface JSZipSupport {
     nodebuffer: boolean;
 }
 
-type Compression = 'STORE' | 'DEFLATE';
+type Compression = "STORE" | "DEFLATE";
 
 /**
  * Depends on the compression type. With `STORE` (no compression), these options are ignored. With
@@ -23,9 +23,9 @@ interface CompressionOptions {
     level: number;
 }
 
-interface Metadata  {
+interface Metadata {
     percent: number;
-    currentFile: string;
+    currentFile: string | null;
 }
 
 type OnUpdateCallback = (metadata: Metadata) => void;
@@ -64,7 +64,9 @@ interface OutputByType {
 //     compressedContent: string|ArrayBuffer|Uint8Array|Buffer;
 // }
 
-type InputFileFormat = InputByType[keyof InputByType] | Promise<InputByType[keyof InputByType]>;
+type InputFileFormat =
+    | InputByType[keyof InputByType]
+    | Promise<InputByType[keyof InputByType]>;
 
 declare namespace JSZip {
     type InputType = keyof InputByType;
@@ -93,8 +95,14 @@ declare namespace JSZip {
          * @param onUpdate a function to call on each internal update.
          * @return Promise the promise of the result.
          */
-        async<T extends OutputType>(type: T, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
-        nodeStream(type?: 'nodebuffer', onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
+        async<T extends OutputType>(
+            type: T,
+            onUpdate?: OnUpdateCallback
+        ): Promise<OutputByType[T]>;
+        nodeStream(
+            type?: "nodebuffer",
+            onUpdate?: OnUpdateCallback
+        ): NodeJS.ReadableStream;
     }
 
     interface JSZipFileOptions {
@@ -159,7 +167,7 @@ declare namespace JSZip {
         /** Stream the files and create file descriptors */
         streamFiles?: boolean;
         /** DOS (default) or UNIX */
-        platform?: 'DOS' | 'UNIX';
+        platform?: "DOS" | "UNIX";
     }
 
     interface JSZipLoadOptions {
@@ -175,17 +183,17 @@ declare namespace JSZip {
         currentFile: string;
     }
 
-    type DataEventCallback<T> = (dataChunk: T, metadata: JSZipMetadata) => void
-    type EndEventCallback = () => void
-    type ErrorEventCallback = (error: Error) => void
+    type DataEventCallback<T> = (dataChunk: T, metadata: JSZipMetadata) => void;
+    type EndEventCallback = () => void;
+    type ErrorEventCallback = (error: Error) => void;
 
     interface JSZipStreamHelper<T> {
         /**
          * Register a listener on an event
          */
-        on(event: 'data', callback: DataEventCallback<T>): this;
-        on(event: 'end', callback: EndEventCallback): this;
-        on(event: 'error', callback: ErrorEventCallback): this;
+        on(event: "data", callback: DataEventCallback<T>): this;
+        on(event: "end", callback: EndEventCallback): this;
+        on(event: "error", callback: ErrorEventCallback): this;
 
         /**
          * Read the whole stream and call a callback with the complete content
@@ -193,7 +201,9 @@ declare namespace JSZip {
          * @param updateCallback The function called every time the stream updates
          * @return A Promise of the full content
          */
-        accumulate(updateCallback?: (metadata: JSZipMetadata) => void): Promise<T>;
+        accumulate(
+            updateCallback?: (metadata: JSZipMetadata) => void
+        ): Promise<T>;
 
         /**
          * Resume the stream if the stream is paused. Once resumed, the stream starts sending data events again
@@ -212,7 +222,7 @@ declare namespace JSZip {
 }
 
 interface JSZip {
-    files: {[key: string]: JSZip.JSZipObject};
+    files: { [key: string]: JSZip.JSZipObject };
 
     /**
      * Get a file from the archive
@@ -238,8 +248,16 @@ interface JSZip {
      * @param options Optional information about the file
      * @return JSZip object
      */
-    file<T extends JSZip.InputType>(path: string, data: InputByType[T] | Promise<InputByType[T]>, options?: JSZip.JSZipFileOptions): this;
-    file<T extends JSZip.InputType>(path: string, data: null, options?: JSZip.JSZipFileOptions & { dir: true }): this;
+    file<T extends JSZip.InputType>(
+        path: string,
+        data: InputByType[T] | Promise<InputByType[T]>,
+        options?: JSZip.JSZipFileOptions
+    ): this;
+    file<T extends JSZip.InputType>(
+        path: string,
+        data: null,
+        options?: JSZip.JSZipFileOptions & { dir: true }
+    ): this;
 
     /**
      * Returns an new JSZip instance with the given folder as root
@@ -262,7 +280,9 @@ interface JSZip {
      *
      * @param callback function
      */
-    forEach(callback: (relativePath: string, file: JSZip.JSZipObject) => void): void;
+    forEach(
+        callback: (relativePath: string, file: JSZip.JSZipObject) => void
+    ): void;
 
     /**
      * Get all files which match the given filter function
@@ -270,7 +290,9 @@ interface JSZip {
      * @param predicate Filter function
      * @return Array of matched elements
      */
-    filter(predicate: (relativePath: string, file: JSZip.JSZipObject) => boolean): JSZip.JSZipObject[];
+    filter(
+        predicate: (relativePath: string, file: JSZip.JSZipObject) => boolean
+    ): JSZip.JSZipObject[];
 
     /**
      * Removes the file or folder from the archive
@@ -287,7 +309,10 @@ interface JSZip {
      * @param onUpdate The optional function called on each internal update with the metadata.
      * @return The serialized archive
      */
-    generateAsync<T extends JSZip.OutputType>(options?: JSZip.JSZipGeneratorOptions<T>, onUpdate?: OnUpdateCallback): Promise<OutputByType[T]>;
+    generateAsync<T extends JSZip.OutputType>(
+        options?: JSZip.JSZipGeneratorOptions<T>,
+        onUpdate?: OnUpdateCallback
+    ): Promise<OutputByType[T]>;
 
     /**
      * Generates a new archive asynchronously
@@ -296,7 +321,10 @@ interface JSZip {
      * @param onUpdate The optional function called on each internal update with the metadata.
      * @return A Node.js `ReadableStream`
      */
-    generateNodeStream(options?: JSZip.JSZipGeneratorOptions<'nodebuffer'>, onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
+    generateNodeStream(
+        options?: JSZip.JSZipGeneratorOptions<"nodebuffer">,
+        onUpdate?: OnUpdateCallback
+    ): NodeJS.ReadableStream;
 
     /**
      * Generates the complete zip file with the internal stream implementation
@@ -304,7 +332,9 @@ interface JSZip {
      * @param options Optional options for the generator
      * @return a StreamHelper
      */
-    generateInternalStream<T extends JSZip.OutputType>(options?: JSZip.JSZipGeneratorOptions<T>): JSZip.JSZipStreamHelper<OutputByType[T]>;
+    generateInternalStream<T extends JSZip.OutputType>(
+        options?: JSZip.JSZipGeneratorOptions<T>
+    ): JSZip.JSZipStreamHelper<OutputByType[T]>;
 
     /**
      * Deserialize zip file asynchronously
@@ -313,12 +343,15 @@ interface JSZip {
      * @param options Options for deserializing
      * @return Returns promise
      */
-    loadAsync(data: InputFileFormat, options?: JSZip.JSZipLoadOptions): Promise<JSZip>;
+    loadAsync(
+        data: InputFileFormat,
+        options?: JSZip.JSZipLoadOptions
+    ): Promise<JSZip>;
 
     /**
      * Create JSZip instance
      */
-    new(): this;
+    new (): this;
 
     (): JSZip;
 


### PR DESCRIPTION
When providing an `onUpdate` callback when generating an archive I've found that when `percent` reaches `100` the `currentFile` property is `null`.

This [comment](https://github.com/Stuk/jszip/blob/38f837313ee94bbef2328c47e0f48fd43ceb3300/lib/generate/ZipFileWorker.js#L349) in the code describes this behavior but the typescript does not match.

The `null` type simply needs to be added to the declaration file.