### PR TITLE
Switch manual download link to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ zip.generateAsync({type:"blob"})
   <strong>With component</strong> : <code>component install Stuk/jszip</code>
 </p>
 <p>
-  <strong>Manually</strong> : <a href="http://github.com/Stuk/jszip/zipball/main">download JSZip</a>
+  <strong>Manually</strong> : <a href="https://github.com/Stuk/jszip/zipball/main">download JSZip</a>
   and include the file <code>dist/jszip.js</code> or <code>dist/jszip.min.js</code>
 </p>
 <br>


### PR DESCRIPTION
Chromium-based browsers block HTTP downloads from HTTPS websites.