### PR TITLE
Add null type to currentFile in JSZipMetadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare namespace JSZip {
 
     interface JSZipMetadata {
         percent: number;
-        currentFile: string;
+        currentFile: string | null;
     }
 
     type DataEventCallback<T> = (dataChunk: T, metadata: JSZipMetadata) => void


### PR DESCRIPTION
I think this was supposed to be done as part of PR #826.

At the moment `OnUpdateCallback` and `Metadata` are not exported so I had to rely on `JSZip.JSZipMetadata`  for a typesafe `onUpdate` callback to `generateAsync`. However, `JSZip.JSZipMetadata` isn't exactly identical to `Metadata` as `Metadata` has a union type that allows `currentfile` to be `null`. I see this was added in PR #826 , but shouldn't it be added to both types?