### PR TITLE
Typescript definitions: Fix JSZip.folder does not return null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -240,9 +240,9 @@ interface JSZip {
      * Returns an new JSZip instance with the given folder as root
      *
      * @param name Name of the folder
-     * @return New JSZip object with the given folder as root or null
+     * @return New JSZip object with the given folder as root
      */
-    folder(name: string): JSZip | null;
+    folder(name: string): JSZip;
 
     /**
      * Returns new JSZip instances with the matching folders as root


### PR DESCRIPTION
#669 added null to the return type according to the documentation in the typedefs, but the documentation in the typedefs is wrong about `JSZip.folder` returning null. `JSZip.folder` does not return null.

This fixes the documentation in the typedefs and the type to match the documented and observable behavior.