### PR TITLE
Typescript definitions: Fix  return type of JSZipGeneratorOptions.encodeFileName

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,7 @@ declare namespace JSZip {
          * @default 'application/zip'
          */
         mimeType?: string;
-        encodeFileName?(filename: string): string;
+        encodeFileName?(filename: string): Buffer;
         /** Stream the files and create file descriptors */
         streamFiles?: boolean;
         /** DOS (default) or UNIX */


### PR DESCRIPTION
fixes #833
Hi.
JSZipGeneratorOptions.encodeFileName is inconsistent with the [document](https://stuk.github.io/jszip/documentation/api_jszip/generate_async.html#encodefilename-option) description and the TypeScript type definition, so fix type definition.