### PR TITLE
fix small typo in documentation examples

### DIFF
--- a/documentation/examples/get-binary-files-ajax.html
+++ b/documentation/examples/get-binary-files-ajax.html
@@ -51,7 +51,7 @@ Fetch API</a> is a new javascript API which may not be available everywhere.
 <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active">
         <a href="#fetch-api-result" aria-controls="fetch-api-result" role="tab" data-toggle="tab">
-            js code
+            result
         </a>
     </li>
     <li role="presentation">


### PR DESCRIPTION
js code was doubled, changed it to 'result'