### PR TITLE
Fix loading Blob in Node environment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -450,25 +450,7 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
 
     // if inputData is already a promise, this flatten it.
     var promise = external.Promise.resolve(inputData).then(function(data) {
-
-
-        var isBlob = support.blob && (data instanceof Blob || ["[object File]", "[object Blob]"].indexOf(Object.prototype.toString.call(data)) !== -1);
-
-        if (isBlob && typeof FileReader !== "undefined") {
-            return new external.Promise(function (resolve, reject) {
-                var reader = new FileReader();
-
-                reader.onload = function(e) {
-                    resolve(e.target.result);
-                };
-                reader.onerror = function(e) {
-                    reject(e.target.error);
-                };
-                reader.readAsArrayBuffer(data);
-            });
-        } else {
-            return data;
-        }
+        return support.blob && data instanceof Blob ? data.arrayBuffer() : data;
     });
 
     return promise.then(function(data) {


### PR DESCRIPTION
I fixed #899. The major problem is due to lack of `FileReader` in Node.

I also cleaned the logic of converting a blob into an array buffer. Note the fact: `FileReader.prototype.readAsArrayBuffer` and `Blob.prototype.arrayBuffer` essentially does the same thing, but the former uses callback while the latter uses promise. Also, because `File` inherits `Blob`, we do not need to specially take care of `File`.

`npm run test` seems fine. Tests all pass.