### PR TITLE
Add compression example to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,13 @@ zip.file("Hello.txt", "Hello World\n");
 const img = zip.folder("images");
 img.file("smile.gif", imgData, {base64: true});
 
+/* 1. Create a zip file with compressed contents by specifying a compression and compression level (1 is "best speed", 9 is "best compression") */
+zip.generateAsync({type:"blob", compression:"DEFLATE", compressionOptions: {level:9}}).then(function(content) {
+    // see FileSaver.js
+    saveAs(content, "example.zip");
+});
+
+/* 2. Or, if you prefer a zip with uncompressed contents, you can omit the compression options */
 zip.generateAsync({type:"blob"}).then(function(content) {
     // see FileSaver.js
     saveAs(content, "example.zip");


### PR DESCRIPTION
By default, JSZip's `generateAsync` doesn't compress the contents of the zip by default, but this isn't communicated in the example in the README.

So this PR adds an example to the README that uses the compression options, which most users would probably want to use. It preserves the non-compressed example below as a second example, in case anyone is wanting to create an uncompressed zip.