### PR TITLE
Fix blob support in Node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        node-version: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -454,21 +454,29 @@ exports.prepareContent = function(name, inputData, isBinary, isOptimizedBinarySt
 
         var isBlob = support.blob && (data instanceof Blob || ["[object File]", "[object Blob]"].indexOf(Object.prototype.toString.call(data)) !== -1);
 
-        if (isBlob && typeof FileReader !== "undefined") {
-            return new external.Promise(function (resolve, reject) {
-                var reader = new FileReader();
+        if (isBlob) {
+            if (typeof Blob.prototype.arrayBuffer !== "undefined") {
+                return data.arrayBuffer();
+            } else if (typeof FileReader !== "undefined") {
+                return new external.Promise(function (resolve, reject) {
+                    var reader = new FileReader();
 
-                reader.onload = function(e) {
-                    resolve(e.target.result);
-                };
-                reader.onerror = function(e) {
-                    reject(e.target.error);
-                };
-                reader.readAsArrayBuffer(data);
-            });
-        } else {
-            return data;
+                    reader.onload = function(e) {
+                        resolve(e.target.result);
+                    };
+                    reader.onerror = function(e) {
+                        reject(e.target.error);
+                    };
+                    reader.readAsArrayBuffer(data);
+                });
+            } else {
+                return external.Promise.reject(
+                    new Error(name + " is a Blob, but we have no way of reading it.")
+                );
+            }
         }
+
+        return data;
     });
 
     return promise.then(function(data) {

--- a/test/asserts/file.js
+++ b/test/asserts/file.js
@@ -244,8 +244,10 @@ QUnit.module("file", function () {
             if (JSZip.support.blob) {
                 QUnit.assert.equal(err, null, testName + "no error");
                 QUnit.assert.ok(blob instanceof Blob, testName + "the result is a instance of Blob");
-                QUnit.assert.equal(blob.type,  "", testName + "the result has the right mime type");
-                QUnit.assert.equal(blob.size, opts.rawData.length, testName + "the result has the right length");
+                if (blob instanceof Blob) {
+                    QUnit.assert.equal(blob.type,  "", testName + "the result has the right mime type");
+                    QUnit.assert.equal(blob.size, opts.rawData.length, testName + "the result has the right length");
+                }
             } else {
                 QUnit.assert.equal(blob, null, testName + "no data");
                 QUnit.assert.ok(err.message.match("not supported by this platform"), testName + "the error message is useful");


### PR DESCRIPTION
Resolves #941.

Node has `Blob` but not `FileReader`. Instead, we can convert a blob's contents to an `ArrayBuffer` using `Blob.prototype.arrayBuffer`.

This approach should stick pretty closely to what the code already does (transparently try to convert a `Blob` to an `ArrayBuffer` before doing anything else to it).

I've also fixed the test code so that it doesn't try to read certain properties of the passed blob unless it's actually a `Blob`--if that particular test helper is called with an error, the `blob` argument will be `null`, and we'll get spurious errors that terminate the entire test suite early.